### PR TITLE
Datetime tests pass

### DIFF
--- a/example_js_regex/integration_test/datetime/date_time_extractor_cases.dart
+++ b/example_js_regex/integration_test/datetime/date_time_extractor_cases.dart
@@ -1,0 +1,494 @@
+const dateTimeExtractorTestCases = [
+  {
+    "Input": "I'll go back now",
+    "Results": [
+      {"Text": "now", "Type": "datetime", "Start": 13, "Length": 3}
+    ]
+  },
+  {
+    "Input": "I'll go back as soon as possible",
+    "Results": [
+      {"Text": "as soon as possible", "Type": "datetime", "Start": 13, "Length": 19}
+    ]
+  },
+  {
+    "Input": "I'll go back right now",
+    "Results": [
+      {"Text": "right now", "Type": "datetime", "Start": 13, "Length": 9}
+    ]
+  },
+  {
+    "Input": "I'll go back on 15 at 8:00",
+    "Results": [
+      {"Text": "15 at 8:00", "Type": "datetime", "Start": 16, "Length": 10}
+    ]
+  },
+  {
+    "Input": "I'll go back on 15 at 8:00:30",
+    "Results": [
+      {"Text": "15 at 8:00:30", "Type": "datetime", "Start": 16, "Length": 13}
+    ]
+  },
+  {
+    "Input": "I'll go back on 15, 8pm",
+    "Results": [
+      {"Text": "15, 8pm", "Type": "datetime", "Start": 16, "Length": 7}
+    ]
+  },
+  {
+    "Input": "I'll go back 04/21/2016, 8:00pm",
+    "Results": [
+      {"Text": "04/21/2016, 8:00pm", "Type": "datetime", "Start": 13, "Length": 18}
+    ]
+  },
+  {
+    "Input": "I'll go back 04/21/2016, 8:00:13pm",
+    "Results": [
+      {"Text": "04/21/2016, 8:00:13pm", "Type": "datetime", "Start": 13, "Length": 21}
+    ]
+  },
+  {
+    "Input": "I'll go back Oct. 23 at seven",
+    "Results": [
+      {"Text": "Oct. 23 at seven", "Type": "datetime", "Start": 13, "Length": 16}
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 8:00am",
+    "Results": [
+      {"Text": "October 14 8:00am", "Type": "datetime", "Start": 13, "Length": 17}
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 8:00:00am",
+    "Results": [
+      {"Text": "October 14 8:00:00am", "Type": "datetime", "Start": 13, "Length": 20}
+    ]
+  },
+  {
+    "Input": "I'll go back October 14, 8:00am",
+    "Results": [
+      {"Text": "October 14, 8:00am", "Type": "datetime", "Start": 13, "Length": 18}
+    ]
+  },
+  {
+    "Input": "I'll go back October 14, 8:00:01am",
+    "Results": [
+      {"Text": "October 14, 8:00:01am", "Type": "datetime", "Start": 13, "Length": 21}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow 8:00am",
+    "Results": [
+      {"Text": "tomorrow 8:00am", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow around 8:00am",
+    "Results": [
+      {"Text": "tomorrow around 8:00am", "Type": "datetime", "Start": 13, "Length": 22}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow for 8:00am",
+    "Results": [
+      {"Text": "tomorrow for 8:00am", "Type": "datetime", "Start": 13, "Length": 19}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow 8:00:05am",
+    "Results": [
+      {"Text": "tomorrow 8:00:05am", "Type": "datetime", "Start": 13, "Length": 18}
+    ]
+  },
+  {
+    "Input": "I'll go back next friday at half past 3 ",
+    "Results": [
+      {"Text": "next friday at half past 3", "Type": "datetime", "Start": 13, "Length": 26}
+    ]
+  },
+  {
+    "Input": "I'll go back May 5, 2016, 20 min past eight in the evening",
+    "Results": [
+      {"Text": "May 5, 2016, 20 min past eight in the evening", "Type": "datetime", "Start": 13, "Length": 45}
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm on 15",
+    "Results": [
+      {"Text": "8pm on 15", "Type": "datetime", "Start": 13, "Length": 9}
+    ]
+  },
+  {
+    "Input": "I'll go back at seven on 15",
+    "Results": [
+      {"Text": "seven on 15", "Type": "datetime", "Start": 16, "Length": 11}
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm next sunday",
+    "Results": [
+      {"Text": "8pm next sunday", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm today",
+    "Results": [
+      {"Text": "8pm today", "Type": "datetime", "Start": 13, "Length": 9}
+    ]
+  },
+  {
+    "Input": "I'll go back a quarter to seven tomorrow",
+    "Results": [
+      {"Text": "a quarter to seven tomorrow", "Type": "datetime", "Start": 13, "Length": 27}
+    ]
+  },
+  {
+    "Input": "I'll go back 19:00, 2016-12-22",
+    "Results": [
+      {"Text": "19:00, 2016-12-22", "Type": "datetime", "Start": 13, "Length": 17}
+    ]
+  },
+  {
+    "Input": "I'll go back seven o'clock tomorrow",
+    "Results": [
+      {"Text": "seven o'clock tomorrow", "Type": "datetime", "Start": 13, "Length": 22}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow morning at 7",
+    "Results": [
+      {"Text": "tomorrow morning at 7", "Type": "datetime", "Start": 13, "Length": 21}
+    ]
+  },
+  {
+    "Input": "I'll go back 7:00 on Sunday afternoon",
+    "Results": [
+      {"Text": "7:00 on Sunday afternoon", "Type": "datetime", "Start": 13, "Length": 24}
+    ]
+  },
+  {
+    "Input": "I'll go back twenty minutes past five tomorrow morning",
+    "Results": [
+      {"Text": "twenty minutes past five tomorrow morning", "Type": "datetime", "Start": 13, "Length": 41}
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 8:00, October 14",
+    "Results": [
+      {"Text": "October 14 8:00", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back 7, this morning",
+    "Results": [
+      {"Text": "7, this morning", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm in the evening, Monday",
+    "Results": [
+      {"Text": "8pm in the evening, Monday", "Type": "datetime", "Start": 13, "Length": 26}
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm in the evening, 1st Jan",
+    "Results": [
+      {"Text": "8pm in the evening, 1st Jan", "Type": "datetime", "Start": 13, "Length": 27}
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm in the evening, 1 Jan",
+    "Results": [
+      {"Text": "8pm in the evening, 1 Jan", "Type": "datetime", "Start": 13, "Length": 25}
+    ]
+  },
+  {
+    "Input": "I'll go back 10pm tonight",
+    "Results": [
+      {"Text": "10pm tonight", "Type": "datetime", "Start": 13, "Length": 12}
+    ]
+  },
+  {
+    "Input": "I'll go back 8am this morning",
+    "Results": [
+      {"Text": "8am this morning", "Type": "datetime", "Start": 13, "Length": 16}
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm this evening",
+    "Results": [
+      {"Text": "8pm this evening", "Type": "datetime", "Start": 13, "Length": 16}
+    ]
+  },
+  {
+    "Input": "I'll go back tonight around 7",
+    "Results": [
+      {"Text": "tonight around 7", "Type": "datetime", "Start": 13, "Length": 16}
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at 7",
+    "Results": [
+      {"Text": "this morning at 7", "Type": "datetime", "Start": 13, "Length": 17}
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at 7pm",
+    "Results": [
+      {"Text": "this morning at 7pm", "Type": "datetime", "Start": 13, "Length": 19}
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at seven",
+    "Results": [
+      {"Text": "this morning at seven", "Type": "datetime", "Start": 13, "Length": 21}
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at 7:00",
+    "Results": [
+      {"Text": "this morning at 7:00", "Type": "datetime", "Start": 13, "Length": 20}
+    ]
+  },
+  {
+    "Input": "I'll go back this night at 7",
+    "Results": [
+      {"Text": "this night at 7", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back tonight at 7",
+    "Results": [
+      {"Text": "tonight at 7", "Type": "datetime", "Start": 13, "Length": 12}
+    ]
+  },
+  {
+    "Input": "for 2 people tonight at 9:30 pm",
+    "Results": [
+      {"Text": "tonight at 9:30 pm", "Type": "datetime", "Start": 13, "Length": 18}
+    ]
+  },
+  {
+    "Input": "for 2 people tonight at 9:30:31 pm",
+    "Results": [
+      {"Text": "tonight at 9:30:31 pm", "Type": "datetime", "Start": 13, "Length": 21}
+    ]
+  },
+  {
+    "Input": "I'll go back the end of the day",
+    "Results": [
+      {"Text": "the end of the day", "Type": "datetime", "Start": 13, "Length": 18}
+    ]
+  },
+  {
+    "Input": "I'll go back end of tomorrow",
+    "Results": [
+      {"Text": "end of tomorrow", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back end of the sunday",
+    "Results": [
+      {"Text": "end of the sunday", "Type": "datetime", "Start": 13, "Length": 17}
+    ]
+  },
+  {
+    "Input": "I'll go back at 5th at 4 a.m.",
+    "Results": [
+      {"Text": "5th at 4 a.m.", "Type": "datetime", "Start": 16, "Length": 13}
+    ]
+  },
+  {
+    "Input": "I'll go back 2016-12-16T12:23:59",
+    "Results": [
+      {"Text": "2016-12-16T12:23:59", "Type": "datetime", "Start": 13, "Length": 19}
+    ]
+  },
+  {
+    "Input": "I'll go back in 5 hours",
+    "Results": [
+      {"Text": "in 5 hours", "Type": "datetime", "Start": 13, "Length": 10}
+    ]
+  },
+  {
+    "Input": "see if I am available for 3pm on Sun",
+    "Results": [
+      {"Text": "3pm on Sun", "Type": "datetime", "Start": 26, "Length": 10}
+    ]
+  },
+  {
+    "Input": "Set appointment for tomorrow morning at 9 o'clock.",
+    "Results": [
+      {"Text": "tomorrow morning at 9 o'clock", "Type": "datetime", "Start": 20, "Length": 29}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow morning at 9 o'clock",
+    "Results": [
+      {"Text": "tomorrow morning at 9 o'clock", "Type": "datetime", "Start": 13, "Length": 29}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow morning at 9 oclock",
+    "Results": [
+      {"Text": "tomorrow morning at 9 oclock", "Type": "datetime", "Start": 13, "Length": 28}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow at 9 o'clock",
+    "Results": [
+      {"Text": "tomorrow at 9 o'clock", "Type": "datetime", "Start": 13, "Length": 21}
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow at 9 oclock",
+    "Results": [
+      {"Text": "tomorrow at 9 oclock", "Type": "datetime", "Start": 13, "Length": 20}
+    ]
+  },
+  {
+    "Input": "this friday at one o'clock pm",
+    "Results": [
+      {"Text": "this friday at one o'clock pm", "Type": "datetime", "Start": 0, "Length": 29}
+    ]
+  },
+  {
+    "Input": "ADD LUNCH AT 12:30 PM ON FRI",
+    "NotSupported": "javascript, Java",
+    "Results": [
+      {"Text": "12:30 PM ON FRI", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "Add 649 midnight tonight",
+    "Results": [
+      {"Text": "midnight tonight", "Type": "datetime", "Start": 8, "Length": 16}
+    ]
+  },
+  {
+    "Input": "I'll go back August 1st 11 AM",
+    "Results": [
+      {"Text": "August 1st 11 AM", "Type": "datetime", "Start": 13, "Length": 16}
+    ]
+  },
+  {
+    "Input": "I'll go back August 1st 11 pm",
+    "Results": [
+      {"Text": "August 1st 11 pm", "Type": "datetime", "Start": 13, "Length": 16}
+    ]
+  },
+  {
+    "Input": "I'll go back August 1st 11 p.m.",
+    "Results": [
+      {"Text": "August 1st 11 p.m.", "Type": "datetime", "Start": 13, "Length": 18}
+    ]
+  },
+  {
+    "Input": "I'll go back 25/02 11 am",
+    "Results": [
+      {"Text": "25/02 11 am", "Type": "datetime", "Start": 13, "Length": 11}
+    ]
+  },
+  {
+    "Input": "I'll go back 6 Jan 2017 - 6:37am",
+    "Results": [
+      {"Text": "6 Jan 2017 - 6:37am", "Type": "datetime", "Start": 13, "Length": 19}
+    ]
+  },
+  {
+    "Input": "16. Nov. 2016 10:38",
+    "Results": [
+      {"Text": "16. Nov. 2016 10:38", "Type": "datetime", "Start": 0, "Length": 19}
+    ]
+  },
+  {
+    "Input": "I will leave 1 day 2 hours later",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {"Text": "1 day 2 hours later", "Type": "datetime", "Start": 13, "Length": 19}
+    ]
+  },
+  {
+    "Input": "I will be busy in an hour, so call me later",
+    "Results": [
+      {"Text": "in an hour", "Type": "datetime", "Start": 15, "Length": 10}
+    ]
+  },
+  {
+    "Input": "I met him 2 months 1 day 2 hours ago",
+    "NotSupported": "javascript",
+    "Results": [
+      {"Text": "2 months 1 day 2 hours ago", "Type": "datetime", "Start": 10, "Length": 26}
+    ]
+  },
+  {
+    "Input": "I will leave 1 day 30 minutes later",
+    "NotSupported": "javascript",
+    "Results": [
+      {"Text": "1 day 30 minutes later", "Type": "datetime", "Start": 13, "Length": 22}
+    ]
+  },
+  {
+    "Input": "I will leave in 2 minutes",
+    "Results": [
+      {"Text": "in 2 minutes", "Type": "datetime", "Start": 13, "Length": 12}
+    ]
+  },
+  {
+    "Input": "Please book Skype call today at 9a.",
+    "Results": [
+      {"Text": "today at 9a", "Type": "datetime", "Start": 23, "Length": 11}
+    ]
+  },
+  {
+    "Input": "Please book Skype call today at 9p.",
+    "Results": [
+      {"Text": "today at 9p", "Type": "datetime", "Start": 23, "Length": 11}
+    ]
+  },
+  {
+    "Input": "I will leave in 2 hours",
+    "Results": [
+      {"Text": "in 2 hours", "Type": "datetime", "Start": 13, "Length": 10}
+    ]
+  },
+  {
+    "Input": "I will go back on wed Oct 26 15:50:06 2016.",
+    "NotSupported": "java,javascript",
+    "Results": [
+      {"Text": "wed Oct 26 15:50:06 2016", "Type": "datetime", "Start": 18, "Length": 24}
+    ]
+  },
+  {
+    "Input": "Wed Oct 26 15:50:06 2016 is not a day in 2019.",
+    "NotSupported": "java,javascript",
+    "Results": [
+      {"Text": "Wed Oct 26 15:50:06 2016", "Type": "datetime", "Start": 0, "Length": 24}
+    ]
+  },
+  {
+    "Input": "I'll go back at 8.30pm today",
+    "Results": [
+      {"Text": "at 8.30pm today", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back today at 8.30pm",
+    "Results": [
+      {"Text": "today at 8.30pm", "Type": "datetime", "Start": 13, "Length": 15}
+    ]
+  },
+  {
+    "Input": "I'll go back 8.30pm today",
+    "Results": [
+      {"Text": "8.30pm today", "Type": "datetime", "Start": 13, "Length": 12}
+    ]
+  },
+  {
+    "Input": "I'll go back 8.30 pm today",
+    "Results": [
+      {"Text": "8.30 pm today", "Type": "datetime", "Start": 13, "Length": 13}
+    ]
+  }
+];

--- a/example_js_regex/integration_test/datetime/date_time_extractor_test.dart
+++ b/example_js_regex/integration_test/datetime/date_time_extractor_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nlp/nlp.dart';
+
+import 'date_time_extractor_cases.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DateTime > extractor >', () {
+    for (final testCase in dateTimeExtractorTestCases) {
+      final input = testCase["Input"] as String;
+      testWidgets(input, (tester) async {
+        final extractor = BaseDateTimeExtractor(
+          EnglishDateTimeExtractorConfiguration(
+            EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None),
+          ),
+        );
+
+        DateTime? referenceDate;
+
+        final context = testCase["Context"] as Map<String, dynamic>?;
+
+        if (context != null) {
+          referenceDate = DateTime.parse(context["ReferenceDateTime"]);
+        }
+
+        final extractions = extractor.extractDateTime(input, referenceDate ?? DateTime.now());
+
+        final actualResults = extractions.map((extraction) => extraction.toTestCaseJson()).toList();
+        final expectedResults = testCase["Results"] as List<dynamic>;
+
+        expect(actualResults, expectedResults);
+      });
+    }
+  });
+}

--- a/example_js_regex/integration_test/datetime/date_time_parser_cases.dart
+++ b/example_js_regex/integration_test/datetime/date_time_parser_cases.dart
@@ -1,0 +1,1097 @@
+const dateTimeParserTestCases = [
+  {
+    "Input": "I'll go back now",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "now",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "PRESENT_REF",
+          "FutureResolution": {"dateTime": "2016-11-07 00:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 00:00:00"}
+        },
+        "Start": 13,
+        "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back as soon as possible",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "as soon as possible",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "FUTURE_REF",
+          "FutureResolution": {"dateTime": "2016-11-07 00:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 00:00:00"}
+        },
+        "Start": 13,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back on 15 at 8:00",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "15 at 8:00",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-15T08:00",
+          "FutureResolution": {"dateTime": "2016-11-15 08:00:00"},
+          "PastResolution": {"dateTime": "2016-10-15 08:00:00"}
+        },
+        "Start": 16,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back on 15 at 8:00:20",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "15 at 8:00:20",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-15T08:00:20",
+          "FutureResolution": {"dateTime": "2016-11-15 08:00:20"},
+          "PastResolution": {"dateTime": "2016-10-15 08:00:20"}
+        },
+        "Start": 16,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back on 15, 8pm",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "15, 8pm",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-15T20",
+          "FutureResolution": {"dateTime": "2016-11-15 20:00:00"},
+          "PastResolution": {"dateTime": "2016-10-15 20:00:00"}
+        },
+        "Start": 16,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back at 5th at 4 a.m.",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "5th at 4 a.m.",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-05T04",
+          "FutureResolution": {"dateTime": "2016-12-05 04:00:00"},
+          "PastResolution": {"dateTime": "2016-11-05 04:00:00"}
+        },
+        "Start": 16,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 04/21/2016, 8:00pm",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "04/21/2016, 8:00pm",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-04-21T20:00",
+          "FutureResolution": {"dateTime": "2016-04-21 20:00:00"},
+          "PastResolution": {"dateTime": "2016-04-21 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 04/21/2016, 8:00:20pm",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "04/21/2016, 8:00:20pm",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-04-21T20:00:20",
+          "FutureResolution": {"dateTime": "2016-04-21 20:00:20"},
+          "PastResolution": {"dateTime": "2016-04-21 20:00:20"}
+        },
+        "Start": 13,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back Oct.23 at seven",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "Oct.23 at seven",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-23T07",
+          "FutureResolution": {"dateTime": "2017-10-23 07:00:00"},
+          "PastResolution": {"dateTime": "2016-10-23 07:00:00"}
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 8:00am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "October 14 8:00am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-14T08:00",
+          "FutureResolution": {"dateTime": "2017-10-14 08:00:00"},
+          "PastResolution": {"dateTime": "2016-10-14 08:00:00"}
+        },
+        "Start": 13,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 8:00:31am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "October 14 8:00:31am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-14T08:00:31",
+          "FutureResolution": {"dateTime": "2017-10-14 08:00:31"},
+          "PastResolution": {"dateTime": "2016-10-14 08:00:31"}
+        },
+        "Start": 13,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 around 8:00am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "October 14 around 8:00am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-14T08:00",
+          "FutureResolution": {"dateTime": "2017-10-14 08:00:00"},
+          "PastResolution": {"dateTime": "2016-10-14 08:00:00"}
+        },
+        "Start": 13,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 for 8:00:31am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "October 14 for 8:00:31am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-14T08:00:31",
+          "FutureResolution": {"dateTime": "2017-10-14 08:00:31"},
+          "PastResolution": {"dateTime": "2016-10-14 08:00:31"}
+        },
+        "Start": 13,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back October 14, 8:00am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "October 14, 8:00am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-14T08:00",
+          "FutureResolution": {"dateTime": "2017-10-14 08:00:00"},
+          "PastResolution": {"dateTime": "2016-10-14 08:00:00"}
+        },
+        "Start": 13,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back October 14, 8:00:25am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "October 14, 8:00:25am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-14T08:00:25",
+          "FutureResolution": {"dateTime": "2017-10-14 08:00:25"},
+          "PastResolution": {"dateTime": "2016-10-14 08:00:25"}
+        },
+        "Start": 13,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back May 5, 2016, 20 min past eight in the evening",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "May 5, 2016, 20 min past eight in the evening",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-05-05T20:20",
+          "FutureResolution": {"dateTime": "2016-05-05 20:20:00"},
+          "PastResolution": {"dateTime": "2016-05-05 20:20:00"}
+        },
+        "Start": 13,
+        "Length": 45
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm on 15",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8pm on 15",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-15T20",
+          "FutureResolution": {"dateTime": "2016-11-15 20:00:00"},
+          "PastResolution": {"dateTime": "2016-10-15 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm on the 15",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8pm on the 15",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-15T20",
+          "FutureResolution": {"dateTime": "2016-11-15 20:00:00"},
+          "PastResolution": {"dateTime": "2016-10-15 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back at seven on 15",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "seven on 15",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-15T07",
+          "FutureResolution": {"dateTime": "2016-11-15 07:00:00"},
+          "PastResolution": {"dateTime": "2016-10-15 07:00:00"}
+        },
+        "Start": 16,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm today",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8pm today",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T20",
+          "FutureResolution": {"dateTime": "2016-11-07 20:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back a quarter to seven tomorrow",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "a quarter to seven tomorrow",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-08T06:45",
+          "FutureResolution": {"dateTime": "2016-11-08 06:45:00"},
+          "PastResolution": {"dateTime": "2016-11-08 06:45:00"}
+        },
+        "Start": 13,
+        "Length": 27
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 19:00, 2016-12-22",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "19:00, 2016-12-22",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-12-22T19:00",
+          "FutureResolution": {"dateTime": "2016-12-22 19:00:00"},
+          "PastResolution": {"dateTime": "2016-12-22 19:00:00"}
+        },
+        "Start": 13,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow 8:00am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "tomorrow 8:00am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-08T08:00",
+          "FutureResolution": {"dateTime": "2016-11-08 08:00:00"},
+          "PastResolution": {"dateTime": "2016-11-08 08:00:00"}
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back tomorrow morning at 7",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "tomorrow morning at 7",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-08T07",
+          "FutureResolution": {"dateTime": "2016-11-08 07:00:00"},
+          "PastResolution": {"dateTime": "2016-11-08 07:00:00"}
+        },
+        "Start": 13,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back tonight around 7",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "tonight around 7",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T19",
+          "FutureResolution": {"dateTime": "2016-11-07 19:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 19:00:00"}
+        },
+        "Start": 13,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 7:00 on next Sunday afternoon",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "7:00 on next Sunday afternoon",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-20T19:00",
+          "FutureResolution": {"dateTime": "2016-11-20 19:00:00"},
+          "PastResolution": {"dateTime": "2016-11-20 19:00:00"}
+        },
+        "Start": 13,
+        "Length": 29
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back twenty minutes past five tomorrow morning",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "twenty minutes past five tomorrow morning",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-08T05:20",
+          "FutureResolution": {"dateTime": "2016-11-08 05:20:00"},
+          "PastResolution": {"dateTime": "2016-11-08 05:20:00"}
+        },
+        "Start": 13,
+        "Length": 41
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 7, this morning",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "7, this morning",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T07",
+          "FutureResolution": {"dateTime": "2016-11-07 07:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 07:00:00"}
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 10, tonight",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "10, tonight",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T22",
+          "FutureResolution": {"dateTime": "2016-11-07 22:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 22:00:00"}
+        },
+        "Start": 13,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm in the evening, Sunday",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8pm in the evening, Sunday",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-WXX-7T20",
+          "FutureResolution": {"dateTime": "2016-11-13 20:00:00"},
+          "PastResolution": {"dateTime": "2016-11-06 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 26
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm in the evening, 1st Jan",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8pm in the evening, 1st Jan",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-01-01T20",
+          "FutureResolution": {"dateTime": "2017-01-01 20:00:00"},
+          "PastResolution": {"dateTime": "2016-01-01 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 27
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm in the evening, 1 Jan",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8pm in the evening, 1 Jan",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-01-01T20",
+          "FutureResolution": {"dateTime": "2017-01-01 20:00:00"},
+          "PastResolution": {"dateTime": "2016-01-01 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 10pm tonight",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "10pm tonight",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T22",
+          "FutureResolution": {"dateTime": "2016-11-07 22:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 22:00:00"}
+        },
+        "Start": 13,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8am this morning",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8am this morning",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T08",
+          "FutureResolution": {"dateTime": "2016-11-07 08:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 08:00:00"}
+        },
+        "Start": 13,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8pm this evening",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "8pm this evening",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T20",
+          "FutureResolution": {"dateTime": "2016-11-07 20:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 20:00:00"}
+        },
+        "Start": 13,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back the end of the day",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "the end of the day",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T23:59:59",
+          "FutureResolution": {"dateTime": "2016-11-07 23:59:59"},
+          "PastResolution": {"dateTime": "2016-11-07 23:59:59"}
+        },
+        "Start": 13,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back end of tomorrow",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "end of tomorrow",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-08T23:59:59",
+          "FutureResolution": {"dateTime": "2016-11-08 23:59:59"},
+          "PastResolution": {"dateTime": "2016-11-08 23:59:59"}
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back end of the sunday",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "end of the sunday",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-WXX-7T23:59:59",
+          "FutureResolution": {"dateTime": "2016-11-13 23:59:59"},
+          "PastResolution": {"dateTime": "2016-11-06 23:59:59"}
+        },
+        "Start": 13,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back in 5 hours",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "in 5 hours",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T05:00:00",
+          "FutureResolution": {"dateTime": "2016-11-07 05:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 05:00:00"}
+        },
+        "Start": 13,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back on 15 at 8:00:24",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "15 at 8:00:24",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-XX-15T08:00:24",
+          "FutureResolution": {"dateTime": "2016-11-15 08:00:24"},
+          "PastResolution": {"dateTime": "2016-10-15 08:00:24"}
+        },
+        "Start": 16,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 04/21/2016, 8:00:24pm",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "04/21/2016, 8:00:24pm",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-04-21T20:00:24",
+          "FutureResolution": {"dateTime": "2016-04-21 20:00:24"},
+          "PastResolution": {"dateTime": "2016-04-21 20:00:24"}
+        },
+        "Start": 13,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back October 14 8:00:13am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "October 14 8:00:13am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "XXXX-10-14T08:00:13",
+          "FutureResolution": {"dateTime": "2017-10-14 08:00:13"},
+          "PastResolution": {"dateTime": "2016-10-14 08:00:13"}
+        },
+        "Start": 13,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at 7",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "this morning at 7",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T07",
+          "FutureResolution": {"dateTime": "2016-11-07 07:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 07:00:00"}
+        },
+        "Start": 13,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at 7am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "this morning at 7am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T07",
+          "FutureResolution": {"dateTime": "2016-11-07 07:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 07:00:00"}
+        },
+        "Start": 13,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at seven",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "this morning at seven",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T07",
+          "FutureResolution": {"dateTime": "2016-11-07 07:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 07:00:00"}
+        },
+        "Start": 13,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back this morning at 7:00",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "this morning at 7:00",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T07:00",
+          "FutureResolution": {"dateTime": "2016-11-07 07:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 07:00:00"}
+        },
+        "Start": 13,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back this night at 7",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "this night at 7",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T19",
+          "FutureResolution": {"dateTime": "2016-11-07 19:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 19:00:00"}
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back tonight at 7",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "tonight at 7",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-07T19",
+          "FutureResolution": {"dateTime": "2016-11-07 19:00:00"},
+          "PastResolution": {"dateTime": "2016-11-07 19:00:00"}
+        },
+        "Start": 13,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 2016-12-16T12:23:59",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "2016-12-16T12:23:59",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-12-16T12:23:59",
+          "FutureResolution": {"dateTime": "2016-12-16 12:23:59"},
+          "PastResolution": {"dateTime": "2016-12-16 12:23:59"}
+        },
+        "Start": 13,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 6 jan 2017 - 6:37am",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "6 jan 2017 - 6:37am",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2017-01-06T06:37",
+          "FutureResolution": {"dateTime": "2017-01-06 06:37:00"},
+          "PastResolution": {"dateTime": "2017-01-06 06:37:00"}
+        },
+        "Start": 13,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "16. Nov. 2016 10:38",
+    "Context": {"ReferenceDateTime": "2016-11-07T00:00:00"},
+    "Results": [
+      {
+        "Text": "16. Nov. 2016 10:38",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-11-16T10:38",
+          "FutureResolution": {"dateTime": "2016-11-16 10:38:00"},
+          "PastResolution": {"dateTime": "2016-11-16 10:38:00"}
+        },
+        "Start": 0,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "I will leave 1 day 2 hours later",
+    "Context": {"ReferenceDateTime": "2017-11-23T19:00:00"},
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "1 day 2 hours later",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2017-11-24T21:00:00",
+          "FutureResolution": {"dateTime": "2017-11-24 21:00:00"},
+          "PastResolution": {"dateTime": "2017-11-24 21:00:00"}
+        },
+        "Start": 13,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "We met 1 month 2 days 2 hours 30 mins ago",
+    "Context": {"ReferenceDateTime": "2017-11-23T19:15:00"},
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "1 month 2 days 2 hours 30 mins ago",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2017-10-21T16:45:00",
+          "FutureResolution": {"dateTime": "2017-10-21 16:45:00"},
+          "PastResolution": {"dateTime": "2017-10-21 16:45:00"}
+        },
+        "Start": 7,
+        "Length": 34
+      }
+    ]
+  },
+  {
+    "Input": "I will be busy in an hour, so call me later",
+    "Context": {"ReferenceDateTime": "2017-11-23T00:00:00"},
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "in an hour",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2017-11-23T01:00:00",
+          "FutureResolution": {"dateTime": "2017-11-23 01:00:00"},
+          "PastResolution": {"dateTime": "2017-11-23 01:00:00"}
+        },
+        "Start": 15,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "I will be free in less than an hour, so call me later",
+    "Context": {"ReferenceDateTime": "2017-11-23T00:00:00"},
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "in less than an hour",
+        "Type": "datetime",
+        "Value": {
+          "Mod": "less",
+          "Timex": "2017-11-23T01:00:00",
+          "FutureResolution": {"dateTime": "2017-11-23 01:00:00"},
+          "PastResolution": {"dateTime": "2017-11-23 01:00:00"}
+        },
+        "Start": 15,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "You shouldn't always go to bed end of the day since it will do harm to your health.",
+    "Context": {"ReferenceDateTime": "2018-11-21T12:00:00"},
+    "Results": [
+      {
+        "Text": "end of the day",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2018-11-21T23:59:59",
+          "FutureResolution": {"dateTime": "2018-11-21 23:59:59"},
+          "PastResolution": {"dateTime": "2018-11-21 23:59:59"}
+        },
+        "Start": 31,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "You shouldn't always go to bed end of day since it will do harm to your health.",
+    "Context": {"ReferenceDateTime": "2018-11-21T12:00:00"},
+    "Results": [
+      {
+        "Text": "end of day",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2018-11-21T23:59:59",
+          "FutureResolution": {"dateTime": "2018-11-21 23:59:59"},
+          "PastResolution": {"dateTime": "2018-11-21 23:59:59"}
+        },
+        "Start": 31,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Bob and Alice usually exchange their encrypted messages at the eod.",
+    "Context": {"ReferenceDateTime": "2018-11-21T12:00:00"},
+    "Results": [
+      {
+        "Text": "the eod",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2018-11-21T23:59:59",
+          "FutureResolution": {"dateTime": "2018-11-21 23:59:59"},
+          "PastResolution": {"dateTime": "2018-11-21 23:59:59"}
+        },
+        "Start": 59,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "I will go back on wed Oct 26 15:50:06 2016.",
+    "Context": {"ReferenceDateTime": "2018-11-21T12:00:00"},
+    "NotSupported": "java,javascript, python",
+    "Results": [
+      {
+        "Text": "wed Oct 26 15:50:06 2016",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-10-26T15:50:06",
+          "FutureResolution": {"dateTime": "2016-10-26 15:50:06"},
+          "PastResolution": {"dateTime": "2016-10-26 15:50:06"}
+        },
+        "Start": 18,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "Wed Oct 26 15:50:06 2016 is not a day in 2019.",
+    "Context": {"ReferenceDateTime": "2018-11-21T12:00:00"},
+    "NotSupported": "java,javascript, python",
+    "Results": [
+      {
+        "Text": "Wed Oct 26 15:50:06 2016",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2016-10-26T15:50:06",
+          "FutureResolution": {"dateTime": "2016-10-26 15:50:06"},
+          "PastResolution": {"dateTime": "2016-10-26 15:50:06"}
+        },
+        "Start": 0,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back at 8.30pm today",
+    "Context": {"ReferenceDateTime": "2018-12-26T12:00:00"},
+    "Results": [
+      {
+        "Text": "at 8.30pm today",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2018-12-26T20:30",
+          "FutureResolution": {"dateTime": "2018-12-26 20:30:00"},
+          "PastResolution": {"dateTime": "2018-12-26 20:30:00"}
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back today at 8.30pm",
+    "Context": {"ReferenceDateTime": "2018-12-26T12:00:00"},
+    "Results": [
+      {
+        "Text": "today at 8.30pm",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2018-12-26T20:30",
+          "FutureResolution": {"dateTime": "2018-12-26 20:30:00"},
+          "PastResolution": {"dateTime": "2018-12-26 20:30:00"}
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8.30pm today",
+    "Context": {"ReferenceDateTime": "2018-12-26T12:00:00"},
+    "Results": [
+      {
+        "Text": "8.30pm today",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2018-12-26T20:30",
+          "FutureResolution": {"dateTime": "2018-12-26 20:30:00"},
+          "PastResolution": {"dateTime": "2018-12-26 20:30:00"}
+        },
+        "Start": 13,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back 8.30 pm today",
+    "Context": {"ReferenceDateTime": "2018-12-26T12:00:00"},
+    "Results": [
+      {
+        "Text": "8.30 pm today",
+        "Type": "datetime",
+        "Value": {
+          "Timex": "2018-12-26T20:30",
+          "FutureResolution": {"dateTime": "2018-12-26 20:30:00"},
+          "PastResolution": {"dateTime": "2018-12-26 20:30:00"}
+        },
+        "Start": 13,
+        "Length": 13
+      }
+    ]
+  }
+];

--- a/example_js_regex/integration_test/datetime/date_time_parser_test.dart
+++ b/example_js_regex/integration_test/datetime/date_time_parser_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nlp/nlp.dart';
+
+import 'date_time_parser_cases.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Datetime > parser >', () {
+    print('executing ${dateTimeParserTestCases.length} test cases');
+
+    for (final testCase in dateTimeParserTestCases) {
+      final input = testCase["Input"] as String;
+      testWidgets(input, (tester) async {
+        final extractor = BaseDateTimeExtractor(
+          EnglishDateTimeExtractorConfiguration(
+            EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None),
+          ),
+        );
+
+        final parser = BaseDateTimeParser(
+          EnglishDateTimeParserConfiguration(
+            EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None),
+          ),
+        );
+
+        DateTime? referenceDate;
+
+        final context = testCase["Context"] as Map<String, dynamic>?;
+
+        if (context != null) {
+          referenceDate = DateTime.parse(context["ReferenceDateTime"]);
+        }
+
+        referenceDate ??= DateTime.now();
+
+        final extractions = extractor.extractDateTime(input, referenceDate);
+
+        final actualResults =
+            extractions.map((extraction) => parser.parseDateTime(extraction, referenceDate!).toTestCaseJson()).toList();
+        final expectedResults = testCase["Results"] as List<dynamic>;
+
+        expect(actualResults, expectedResults);
+      });
+    }
+  });
+}

--- a/lib/nlp.dart
+++ b/lib/nlp.dart
@@ -11,6 +11,9 @@ export 'src/date_time/base_date_parser.dart';
 export 'src/date_time/english/english_date_parser_configuration.dart';
 export 'src/date_time/base_datetime_extractor.dart';
 export 'src/date_time/english/english_date_time_extractor_configuration.dart';
+export 'src/date_time/base_time_parser.dart';
+export 'src/date_time/base_datetime_parser.dart';
+export 'src/date_time/english/english_date_time_parser_configuration.dart';
 
 export 'src/duration/base_duration_parser.dart';
 export 'src/duration/duration.dart';

--- a/lib/nlp.dart
+++ b/lib/nlp.dart
@@ -9,6 +9,8 @@ export 'src/date_time/base_date_extractor.dart';
 export 'src/date_time/english_date_extractor.dart';
 export 'src/date_time/base_date_parser.dart';
 export 'src/date_time/english/english_date_parser_configuration.dart';
+export 'src/date_time/base_datetime_extractor.dart';
+export 'src/date_time/english/english_date_time_extractor_configuration.dart';
 
 export 'src/duration/base_duration_parser.dart';
 export 'src/duration/duration.dart';

--- a/lib/src/core/definition_loader.dart
+++ b/lib/src/core/definition_loader.dart
@@ -1,0 +1,13 @@
+class DefinitionLoader {
+  static Map<RegExp, RegExp> LoadAmbiguityFilters(Map<String, String> filters) {
+    var ambiguityFiltersDict = <RegExp, RegExp>{};
+
+    for (var item in filters.entries) {
+      if ("null" != item.key) {
+        ambiguityFiltersDict.putIfAbsent(RegExp(item.key), () => RegExp(item.value));
+      }
+    }
+
+    return ambiguityFiltersDict;
+  }
+}

--- a/lib/src/date_time/ago_later_util.dart
+++ b/lib/src/date_time/ago_later_util.dart
@@ -276,7 +276,7 @@ class AgoLaterUtil {
       if (mode == AgoLaterMode.Date) {
         ret.timex = DateTimeFormatUtil.luisDateFromDateTime(resultDateTime);
       } else if (mode == AgoLaterMode.DateTime) {
-        ret.timex = DateTimeFormatUtil.luisDateFromDateTime(resultDateTime);
+        ret.timex = DateTimeFormatUtil.luisDateTime(resultDateTime);
       }
 
       ret.futureValue = ret.pastValue = resultDateTime;

--- a/lib/src/date_time/base_date_parser.dart
+++ b/lib/src/date_time/base_date_parser.dart
@@ -794,8 +794,10 @@ class BaseDateParser implements IDateTimeParser {
                 data: null,
                 metadata: Metadata(isHoliday: true),
               );
-              innerResult =
-                  config.holidayParser().parseDateTime(holidayEr, referenceDate).value as DateTimeResolutionResult;
+              // TODO: bring back
+              // innerResult =
+              //     config.holidayParser().parseDateTime(holidayEr, referenceDate).value as DateTimeResolutionResult;
+              innerResult = DateTimeResolutionResult();
             }
 
             // Combine parsed results Duration + Date
@@ -1027,6 +1029,10 @@ extension DateTimeExtensions on DateTime {
     return difference(DateTime(year, 1, 1)).inDays + 1;
   }
 
+  DateTime get dateOnly {
+    return DateTime(year, month, day);
+  }
+
   DateTime This(int dayOfWeek) {
     var start = weekday;
     var target = dayOfWeek;
@@ -1113,6 +1119,10 @@ extension DateTimeExtensions on DateTime {
   DateTime AddDays(int days) {
     final newDate = add(Duration(days: days));
     return _adjustTimeZones(newDate);
+  }
+
+  DateTime AddSeconds(int seconds) {
+    return add(Duration(seconds: seconds));
   }
 
   DateTime AddMonths(int months) {

--- a/lib/src/date_time/base_datetime_extractor.dart
+++ b/lib/src/date_time/base_datetime_extractor.dart
@@ -1,0 +1,490 @@
+import 'package:nlp/src/core/extraction.dart';
+import 'package:nlp/src/date_time/ago_later_util.dart';
+import 'package:nlp/src/date_time/base_date_extractor.dart';
+import 'package:nlp/src/date_time/constants.dart';
+import 'package:nlp/src/date_time/date_time_extraction.dart';
+import 'package:nlp/src/date_time/datetime_utility_configuration.dart';
+import 'package:nlp/src/duration/duration.dart';
+import 'package:nlp/src/numbers/number_constants.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class BaseDateTimeExtractor implements IDateTimeExtractor {
+  static String ExtractorName = DateTimeConstants.SYS_DATETIME_DATETIME; // "DateTime";
+
+  BaseDateTimeExtractor(this.config);
+
+  final IDateTimeExtractorConfiguration config;
+
+  @override
+  List<ExtractResult> extract(String input) {
+    return extractDateTime(input, DateTime.now());
+  }
+
+  @override
+  List<ExtractResult> extractDateTime(String text, DateTime reference) {
+    final normalizedText = text.toLowerCase();
+
+    var tokens = <Token>[];
+    tokens.addAll(MergeDateAndTime(normalizedText, reference));
+
+    if (config.options.match(DateTimeOptions.TasksMode)) {
+      tokens.addAll(MergeHolidayAndTime(normalizedText, reference));
+    }
+
+    tokens.addAll(BasicRegexMatch(normalizedText));
+    tokens.addAll(TimeOfTodayBefore(normalizedText, reference));
+    tokens.addAll(TimeOfTodayAfter(normalizedText, reference));
+    tokens.addAll(SpecialTimeOfDate(normalizedText, reference));
+    tokens.addAll(DurationWithBeforeAndAfter(normalizedText, reference));
+
+    return Token.mergeAllTokens(tokens, text, ExtractorName);
+  }
+
+  @override
+  String getExtractorName() => ExtractorName;
+
+  // Match "now"
+  List<Token> BasicRegexMatch(String text) {
+    var ret = <Token>[];
+
+    // Handle "now"
+    var matches = RegExpComposer.getMatchesSimple(config.NowRegExp(), text);
+    for (final match in matches) {
+      ret.add(Token(match.index, match.index + match.length));
+    }
+
+    return ret;
+  }
+
+  // Merge a Date entity and a Time entity, like "at 7 tomorrow"
+  List<Token> MergeDateAndTime(String text, DateTime reference) {
+    var ret = <Token>[];
+    var dateErs = config.DatePointExtractor().extractDateTime(text, reference);
+    if (dateErs.isEmpty) {
+      return ret;
+    }
+
+    var timeErs = config.TimePointExtractor().extractDateTime(text, reference);
+    var timeNumMatches = RegExpComposer.getMatchesSimple(config.NumberAsTimeRegExp(), text);
+    if (timeErs.isEmpty && timeNumMatches.isEmpty) {
+      return ret;
+    }
+
+    var ers = dateErs;
+    ers.addAll(timeErs);
+
+    // handle cases which use numbers as time points
+    // only enabled in CalendarMode
+    if ((config.options.match(DateTimeOptions.CalendarMode))) {
+      var numErs = <ExtractResult>[];
+      for (var idx = 0; idx < timeNumMatches.length; idx++) {
+        var match = timeNumMatches[idx];
+        var node = ExtractResult(
+          start: match.index,
+          length: match.length,
+          text: match.value,
+          type: Constants.SYS_NUM_INTEGER,
+        );
+
+        numErs.add(node);
+      }
+
+      ers.addAll(numErs);
+    }
+
+    // handle cases which use numbers + desc as time points
+    if (timeNumMatches.any((match) => match.getGroup(DateTimeConstants.DescGroupName).length > 0)) {
+      var numDescErs = <ExtractResult>[];
+      for (var match in timeNumMatches.where((match) => match.getGroup(DateTimeConstants.DescGroupName).length > 0)) {
+        var node = ExtractResult(
+          start: match.index,
+          length: match.length,
+          text: match.value,
+          type: DateTimeConstants.SYS_DATETIME_TIME,
+        );
+
+        numDescErs.add(node);
+      }
+
+      ers.addAll(numDescErs);
+    }
+
+    ers.sort((a, b) => a.start - b.start);
+
+    var i = 0;
+    while (i < ers.length - 1) {
+      var j = i + 1;
+      while (j < ers.length && ers[i].isOverlap(ers[j])) {
+        j++;
+      }
+
+      if (j >= ers.length) {
+        break;
+      }
+
+      if ((ers[i].type == DateTimeConstants.SYS_DATETIME_DATE) && ers[j].type == DateTimeConstants.SYS_DATETIME_TIME ||
+          (ers[i].type == DateTimeConstants.SYS_DATETIME_TIME && ers[j].type == DateTimeConstants.SYS_DATETIME_DATE) ||
+          (ers[i].type == DateTimeConstants.SYS_DATETIME_DATE) && ers[j].type == Constants.SYS_NUM_INTEGER) {
+        var middleBegin = ers[i].start + ers[i].length;
+        var middleEnd = ers[j].start;
+        if (middleBegin > middleEnd) {
+          i = j + 1;
+          continue;
+        }
+
+        var middleStr = text.substring(middleBegin, middleEnd).trim();
+        var valid = false;
+
+        // for cases like "tomorrow 3",  "tomorrow at 3"
+        if (ers[j].type == Constants.SYS_NUM_INTEGER) {
+          var match = RegExpComposer.getMatchesSimple(config.DateNumberConnectorRegExp(), middleStr).firstOrNull;
+          if (middleStr.isEmpty || match != null) {
+            valid = true;
+          }
+        } else {
+          // For case like "3 pm or later on monday"
+          var match = config.SuffixAfterRegExp().firstMatch(middleStr);
+          if (match != null) {
+            middleStr = middleStr.substring(match.start + match.length, middleStr.length - match.length).trim();
+          }
+
+          if (!(match != null && middleStr.isEmpty)) {
+            if (config.IsConnector(middleStr)) {
+              valid = true;
+            }
+          }
+        }
+
+        if (valid) {
+          var begin = ers[i].start;
+          var end = (ers[j].start) + (ers[j].length ?? 0);
+
+          end = ExtendWithDateTimeAndYear(begin, end, text, reference);
+
+          ret.add(Token(begin, end));
+          i = j + 1;
+          continue;
+        }
+      }
+
+      i = j;
+    }
+
+    // Handle "in the afternoon" at the end of entity
+    for (var idx = 0; idx < ret.length; idx++) {
+      var afterStr = text.substring(ret[idx].end);
+      var match = config.SuffixRegExp().firstMatch(afterStr);
+      if (match != null) {
+        ret[idx] = Token(ret[idx].start, ret[idx].end + match.length);
+      }
+    }
+
+    // Handle "day" prefixes
+    for (var idx = 0; idx < ret.length; idx++) {
+      var beforeStr = text.substring(0, ret[idx].start);
+      var match = config.UtilityConfiguration().commonDatePrefixRegExp().firstMatch(beforeStr);
+      if (match != null) {
+        ret[idx] = Token(ret[idx].start - match.length, ret[idx].end);
+      }
+    }
+
+    return ret;
+  }
+
+  // Merge a Holiday entity and a Time entity, like "on christmas at 5"
+  List<Token> MergeHolidayAndTime(String text, DateTime reference) {
+    var ret = <Token>[];
+    var dateErs = config.HolidayExtractor().extractDateTime(text, reference);
+    if (dateErs.isEmpty) {
+      return ret;
+    }
+
+    var timeErs = config.TimePointExtractor().extractDateTime(text, reference);
+    var timeNumMatches = config.NumberAsTimeRegExp().allMatches(text).toList();
+    if (timeErs.isEmpty && timeNumMatches.isEmpty) {
+      return ret;
+    }
+
+    var ers = dateErs;
+    ers.addAll(timeErs);
+
+    // handle cases which use numbers as time points
+    // only enabled in CalendarMode
+    if (config.options.match(DateTimeOptions.CalendarMode)) {
+      var numErs = <ExtractResult>[];
+      for (var idx = 0; idx < timeNumMatches.length; idx++) {
+        var match = timeNumMatches[idx];
+        var node = ExtractResult(
+          start: match.start,
+          length: match.length,
+          text: match.input.substring(match.start, match.end),
+          type: Constants.SYS_NUM_INTEGER,
+        );
+
+        numErs.add(node);
+      }
+
+      ers.addAll(numErs);
+    }
+
+    ers.sort((a, b) => a.start - b.start);
+
+    var i = 0;
+    while (i < ers.length - 1) {
+      var j = i + 1;
+      while (j < ers.length && ers[i].isOverlap(ers[j])) {
+        j++;
+      }
+
+      if (j >= ers.length) {
+        break;
+      }
+
+      if (((ers[i].type == DateTimeConstants.SYS_DATETIME_DATE) &&
+              ers[j].type == DateTimeConstants.SYS_DATETIME_TIME) ||
+          ((ers[i].type == DateTimeConstants.SYS_DATETIME_TIME) &&
+              ers[j].type == DateTimeConstants.SYS_DATETIME_DATE) ||
+          (ers[i].type == DateTimeConstants.SYS_DATETIME_DATE) && ers[j].type == Constants.SYS_NUM_INTEGER) {
+        var middleBegin = ers[i].start + ers[i].length;
+        var middleEnd = ers[j].start;
+        if (middleBegin > middleEnd) {
+          i = j + 1;
+          continue;
+        }
+
+        var middleStr = text.substring(middleBegin, middleEnd - middleBegin).trim();
+        var valid = false;
+
+        // for cases like "christmas 3",  "chritmas at 3"
+        if (ers[j].type == Constants.SYS_NUM_INTEGER) {
+          var match = config.DateNumberConnectorRegExp().firstMatch(middleStr);
+          if (middleStr.isEmpty || match != null) {
+            valid = true;
+          }
+        } else {
+          // For case like "3 pm or later on christmas"
+          var match = config.SuffixAfterRegExp().firstMatch(middleStr);
+          if (match != null) {
+            middleStr = middleStr.substring(match.start + match.length, middleStr.length - match.length).trim();
+          }
+
+          if (!(match != null && middleStr.isEmpty)) {
+            if (config.IsConnector(middleStr)) {
+              valid = true;
+            }
+          }
+        }
+
+        if (valid) {
+          var begin = ers[i].start;
+          var end = (ers[j].start) + (ers[j].length);
+
+          end = ExtendWithDateTimeAndYear(begin, end, text, reference);
+
+          ret.add(Token(begin, end));
+          i = j + 1;
+          continue;
+        }
+      }
+
+      i = j;
+    }
+
+    // Handle "in the afternoon" at the end of entity
+    for (var idx = 0; idx < ret.length; idx++) {
+      var afterStr = text.substring(ret[idx].end);
+      var match = config.SuffixRegExp().firstMatch(afterStr);
+      if (match != null) {
+        ret[idx] = Token(ret[idx].start, ret[idx].end + match.length);
+      }
+    }
+
+    // Handle "day" prefixes
+    for (var idx = 0; idx < ret.length; idx++) {
+      var beforeStr = text.substring(0, ret[idx].start);
+      var match = config.UtilityConfiguration().commonDatePrefixRegExp().firstMatch(beforeStr);
+      if (match != null) {
+        ret[idx] = Token(ret[idx].start - match.length, ret[idx].end);
+      }
+    }
+
+    return ret;
+  }
+
+  // Parses a specific time of today, tonight, this afternoon, like "seven this afternoon"
+  List<Token> TimeOfTodayAfter(String text, DateTime reference) {
+    var ret = <Token>[];
+
+    var ers = config.TimePointExtractor().extractDateTime(text, reference);
+
+    for (var er in ers) {
+      var afterStr = text.substring(er.start + er.length);
+      if (afterStr.isEmpty) {
+        continue;
+      }
+
+      var match = config.TimeOfTodayAfterRegExp().firstMatch(afterStr);
+      if (match != null) {
+        var begin = er.start;
+        var end = (er.start) + (er.length) + match.length;
+        ret.add(Token(begin, end));
+      }
+    }
+
+    var matches = config.SimpleTimeOfTodayAfterRegExp().allMatches(text);
+    for (final match in matches) {
+      ret.add(Token(match.start, match.start + match.length));
+    }
+
+    return ret;
+  }
+
+  // Parse a specific time of today, tonight, this afternoon, "this afternoon at 7"
+  List<Token> TimeOfTodayBefore(String text, DateTime reference) {
+    var ret = <Token>[];
+    var ers = config.TimePointExtractor().extractDateTime(text, reference);
+    for (var er in ers) {
+      var beforeStr = text.substring(0, er.start);
+
+      // handle "this morning at 7am"
+      var innerMatch = config.TimeOfDayRegExp().matchBegin(er.text, true);
+
+      if (innerMatch != null) {
+        beforeStr = text.substring(0, (er.start) + innerMatch.length);
+      }
+
+      if (beforeStr.isEmpty) {
+        continue;
+      }
+
+      var match = config.TimeOfTodayBeforeRegExp().firstMatch(beforeStr);
+      if (match != null) {
+        var begin = match.start;
+        var end = er.start + er.length;
+        ret.add(Token(begin, end));
+      }
+    }
+
+    var matches = config.SimpleTimeOfTodayBeforeRegExp().allMatches(text);
+    for (Match match in matches) {
+      ret.add(Token(match.start, match.end));
+    }
+
+    return ret;
+  }
+
+  List<Token> SpecialTimeOfDate(String text, DateTime reference) {
+    var ret = <Token>[];
+    var ers = config.DatePointExtractor().extractDateTime(text, reference);
+
+    // Handle "the end of the day"
+    for (var er in ers) {
+      var beforeStr = text.substring(0, er.start);
+
+      var match = config.SpecificEndOfRegExp().matchEnd(beforeStr, true);
+      if (match != null) {
+        ret.add(Token(match.start, er.start + er.length));
+      } else {
+        var afterStr = text.substring(er.start + er.length);
+
+        match = config.SpecificEndOfRegExp().matchBegin(afterStr, true);
+        if (match != null) {
+          ret.add(Token(er.start, er.start + er.length + match.start + match.length));
+        }
+      }
+    }
+
+    // Handle "eod, end of day"
+    final eod = config.UnspecificEndOfRegExp().allMatches(text);
+    for (Match match in eod) {
+      ret.add(Token(match.start, match.end));
+    }
+
+    return ret;
+  }
+
+  // Process case like "two minutes ago" "three hours later"
+  List<Token> DurationWithBeforeAndAfter(String text, DateTime reference) {
+    var ret = <Token>[];
+
+    var durationEr = config.DurationExtractor().extractDateTime(text, reference);
+    for (var er in durationEr) {
+      // if it is a multiple duration and its type is equal to Date then skip it.
+      if (er.data != null && er.data.toString() == DateTimeConstants.MultipleDuration_Date) {
+        continue;
+      }
+
+      var match = config.UnitRegExp().firstMatch(er.text);
+      if (match == null) {
+        continue;
+      }
+
+      ret = AgoLaterUtil.ExtractorDurationWithBeforeAndAfter(text, er, ret, config.UtilityConfiguration());
+    }
+
+    return ret;
+  }
+
+  // Handle case like "Wed Oct 26 15:50:06 2016" which year and month separated by time.
+  int ExtendWithDateTimeAndYear(int startIndex, int endIndex, String text, DateTime reference) {
+    // Check whether there's a year behind.
+    var suffix = text.substring(endIndex);
+    var matchYear = RegExpComposer.getMatchesSimple(config.YearSuffix(), suffix).firstOrNull;
+    if (matchYear != null && matchYear.index == 0) {
+      var checkYear =
+          config.DatePointExtractor().getYearFromText(RegExpComposer.getMatchesSimple(config.YearRegExp(), text).first);
+      var year = config.DatePointExtractor().getYearFromText(matchYear);
+      if (year >= DateTimeConstants.MinYearNum && year <= DateTimeConstants.MaxYearNum && checkYear == year) {
+        return endIndex + matchYear.length;
+      }
+    }
+
+    return endIndex;
+  }
+}
+
+abstract interface class IDateTimeExtractorConfiguration extends IDateTimeOptionsConfiguration {
+  RegExp NowRegExp();
+
+  RegExp SuffixRegExp();
+
+  RegExp TimeOfTodayAfterRegExp();
+
+  RegExp SimpleTimeOfTodayAfterRegExp();
+
+  RegExp TimeOfTodayBeforeRegExp();
+
+  RegExp SimpleTimeOfTodayBeforeRegExp();
+
+  RegExp TimeOfDayRegExp();
+
+  RegExp SpecificEndOfRegExp();
+
+  RegExp UnspecificEndOfRegExp();
+
+  RegExp UnitRegExp();
+
+  RegExp NumberAsTimeRegExp();
+
+  RegExp DateNumberConnectorRegExp();
+
+  RegExp YearRegExp();
+
+  RegExp YearSuffix();
+
+  RegExp SuffixAfterRegExp();
+
+  IDateTimeExtractor DurationExtractor();
+
+  IDateExtractor DatePointExtractor();
+
+  IDateTimeExtractor TimePointExtractor();
+
+  IExtractor integerExtractor();
+
+  IDateTimeUtilityConfiguration UtilityConfiguration();
+
+  IDateTimeExtractor HolidayExtractor();
+
+  bool IsConnector(String text);
+}

--- a/lib/src/date_time/base_datetime_parser.dart
+++ b/lib/src/date_time/base_datetime_parser.dart
@@ -1,0 +1,591 @@
+import 'package:nlp/src/core/extraction.dart';
+import 'package:nlp/src/core/parser.dart';
+import 'package:nlp/src/date_time/ago_later_util.dart';
+import 'package:nlp/src/date_time/base_date_extractor.dart';
+import 'package:nlp/src/date_time/base_date_parser.dart';
+import 'package:nlp/src/date_time/constants.dart';
+import 'package:nlp/src/date_time/date_time_extraction.dart';
+import 'package:nlp/src/date_time/date_time_format_util.dart';
+import 'package:nlp/src/date_time/date_time_parsing.dart';
+import 'package:nlp/src/date_time/date_time_recognizer.dart';
+import 'package:nlp/src/date_time/date_util.dart';
+import 'package:nlp/src/date_time/datetime_utility_configuration.dart';
+import 'package:nlp/src/duration/base_duration_parser.dart';
+import 'package:nlp/src/duration/duration.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class BaseDateTimeParser implements IDateTimeParser {
+  BaseDateTimeParser(this.config);
+
+  final IDateTimeParserConfiguration config;
+
+  @override
+  List<DateTimeParseResult> filterResults(String query, List<DateTimeParseResult> candidateResults) => candidateResults;
+
+  @override
+  String getParserName() => DateTimeConstants.SYS_DATETIME_DATETIME;
+
+  @override
+  ParseResult? parse(ExtractResult extractResult) {
+    return parseDateTime(extractResult, DateTime.now());
+  }
+
+  @override
+  DateTimeParseResult parseDateTime(ExtractResult er, DateTime reference) {
+    var referenceTime = reference;
+
+    Object? value;
+    if (er.type == getParserName()) {
+      var innerResult = MergeDateAndTime(er.text, referenceTime);
+
+      if ((!innerResult.success) && (config.options.match(DateTimeOptions.TasksMode))) {
+        innerResult = MergeHolidayAndTime(er.text, referenceTime);
+      }
+
+      if (!innerResult.success) {
+        innerResult = ParseBasicRegex(er.text, referenceTime);
+      }
+
+      if (!innerResult.success) {
+        innerResult = ParseTimeOfToday(er.text, referenceTime);
+      }
+
+      if (!innerResult.success) {
+        innerResult = ParseSpecialTimeOfDate(er.text, referenceTime);
+      }
+
+      if (!innerResult.success) {
+        innerResult = ParserDurationWithAgoAndLater(er.text, referenceTime);
+      }
+
+      if (innerResult.success) {
+        innerResult.futureResolution = <String, String>{
+          TimeTypeConstants.DATETIME: DateTimeFormatUtil.formatDateTime(innerResult.futureValue as DateTime),
+        };
+
+        innerResult.pastResolution = <String, String>{
+          TimeTypeConstants.DATETIME: DateTimeFormatUtil.formatDateTime(innerResult.pastValue as DateTime),
+        };
+
+        value = innerResult;
+      }
+    }
+
+    var ret = DateTimeParseResult(
+      text: er.text,
+      start: er.start,
+      length: er.length,
+      type: er.type,
+      data: er.data,
+      value: value,
+      timexStr: value == null ? '' : (value as DateTimeResolutionResult).timex,
+      resolutionStr: '',
+    );
+
+    return ret;
+  }
+
+  // Merge a Date entity and a Time entity
+  DateTimeResolutionResult MergeDateAndTime(String text, DateTime referenceTime) {
+    var ret = DateTimeResolutionResult();
+
+    var er1 = config.DateExtractor().extractDateTime(text, referenceTime);
+    if (er1.isEmpty) {
+      er1 = config.DateExtractor().extractDateTime(config.TokenBeforeDate() + text, referenceTime);
+      if (er1.length == 1) {
+        er1[0].start -= config.TokenBeforeDate().length;
+      } else {
+        return ret;
+      }
+    } else {
+      // This is to understand if there is an ambiguous token in the text. For some languages (e.g. spanish),
+      // the same word could mean different things (e.g a time in the day or an specific day).
+      if (config.ContainsAmbiguousToken(text, er1[0].text)) {
+        return ret;
+      }
+    }
+
+    var er2 = config.TimeExtractor().extractDateTime(text, referenceTime);
+    if (er2.isEmpty) {
+      // Here we filter out "morning, afternoon, night..." time entities
+      var prefixToken = config.TokenBeforeTime();
+      er2 = config.TimeExtractor().extractDateTime(prefixToken + text, referenceTime);
+
+      if (er2.length == 1) {
+        er2[0].start -= prefixToken.length;
+      } else if (er2.isEmpty) {
+        // check whether there is a number being used as a time point
+        bool hasTimeNumber = false;
+        var numErs = config.integerExtractor().extract(text);
+        if (numErs.isNotEmpty && er1.length == 1) {
+          for (var num in numErs) {
+            var middleBegin = er1[0].start + er1[0].length;
+            var middleEnd = num.start;
+            if (middleBegin > middleEnd) {
+              continue;
+            }
+
+            var middleStr = text.substring(middleBegin, middleEnd).trim();
+            var match = config.DateNumberConnectorRegex().firstMatch(middleStr);
+            if (middleStr.isEmpty || match != null) {
+              num.type = DateTimeConstants.SYS_DATETIME_TIME;
+              er2.add(num);
+              hasTimeNumber = true;
+            }
+          }
+        }
+
+        if (!hasTimeNumber) {
+          return ret;
+        }
+      }
+    }
+
+    // Handle cases like "Oct. 5 in the afternoon at 7:00";
+    // in this case "5 in the afternoon" will be extracted as a Time entity
+    var correctTimeIdx = 0;
+    while (correctTimeIdx < er2.length && er2[correctTimeIdx].isOverlap(er1[0])) {
+      correctTimeIdx++;
+    }
+
+    if (correctTimeIdx >= er2.length) {
+      return ret;
+    }
+
+    var pr1 = config.DateParser().parseDateTime(er1[0], referenceTime);
+    var pr2 = config.TimeParser().parseDateTime(er2[correctTimeIdx], referenceTime);
+    if (pr1.value == null || pr2.value == null) {
+      return ret;
+    }
+
+    var futureDate = (pr1.value as DateTimeResolutionResult).futureValue as DateTime;
+    var pastDate = (pr1.value as DateTimeResolutionResult).pastValue as DateTime;
+    var time = (pr2.value as DateTimeResolutionResult).futureValue as DateTime;
+
+    var hour = time.hour;
+    var min = time.minute;
+    var sec = time.second;
+
+    // Handle morning, afternoon
+    if (config.PMTimeRegex().hasMatch(text) && WithinAfternoonHours(hour)) {
+      hour += DateTimeConstants.HalfDayHourCount;
+    } else if (config.AMTimeRegex().hasMatch(text) && WithinMorningHoursAndNoon(hour, min, sec)) {
+      hour -= DateTimeConstants.HalfDayHourCount;
+    }
+
+    var timeStr = pr2.timexStr ?? '';
+    if (timeStr.endsWith(DateTimeConstants.Comment_AmPm)) {
+      timeStr = timeStr.substring(0, timeStr.length - 4);
+    }
+
+    timeStr = "T${hour.toString().padLeft(2, '0')}${timeStr.substring(3)}";
+    ret.timex = (pr1.timexStr ?? '') + timeStr;
+
+    var val = pr2.value as DateTimeResolutionResult;
+    if (hour <= DateTimeConstants.HalfDayHourCount &&
+        !config.PMTimeRegex().hasMatch(text) &&
+        !config.AMTimeRegex().hasMatch(text) &&
+        val.comment?.isNotEmpty == true) {
+      ret.comment = DateTimeConstants.Comment_AmPm;
+    }
+
+    ret.futureValue = DateUtil.createSafeDate(futureDate.year, futureDate.month, futureDate.day, hour, min, sec);
+    ret.pastValue = DateUtil.createSafeDate(pastDate.year, pastDate.month, pastDate.day, hour, min, sec);
+
+    // Handle case like "Wed Oct 26 15:50:06 2016" which year and month separated by time.
+    var timeSuffix = text.substring(er2[0].start + er2[0].length);
+    var matchYear = RegExpComposer.getMatchesSimple(config.YearRegex(), timeSuffix).firstOrNull;
+    if (matchYear != null &&
+        ((pr1.value as DateTimeResolutionResult).futureValue as DateTime).year !=
+            ((pr1.value as DateTimeResolutionResult).pastValue as DateTime).year) {
+      var year = (config.DateExtractor() as BaseDateExtractor).getYearFromText(matchYear);
+      var dateSuffix = text.substring(er1[0].start + er1[0].length);
+      var checkYear =
+          config.DateExtractor().getYearFromText(RegExpComposer.getMatchesSimple(config.YearRegex(), dateSuffix).first);
+
+      if (year >= DateTimeConstants.MinYearNum && year <= DateTimeConstants.MaxYearNum && year == checkYear) {
+        ret.futureValue = DateUtil.createSafeDate(year, futureDate.month, futureDate.day, hour, min, sec);
+        ret.pastValue = DateUtil.createSafeDate(year, pastDate.month, pastDate.day, hour, min, sec);
+        ret.timex = year.toString() + (pr1.timexStr ?? '').substring(4) + timeStr;
+      }
+    }
+
+    ret.success = true;
+
+    // Change the value of time object
+    pr2.timexStr = timeStr;
+    if (ret.comment?.isNotEmpty == true) {
+      (pr2.value as DateTimeResolutionResult).comment =
+          ret.comment == DateTimeConstants.Comment_AmPm ? DateTimeConstants.Comment_AmPm : '';
+    }
+
+    // Add the date and time object in case we want to split them
+    ret.subDateTimeEntities = <Object>[pr1, pr2];
+
+    // Add timezone
+    ret.timeZoneResolution = (pr2.value as DateTimeResolutionResult).timeZoneResolution;
+
+    return ret;
+  }
+
+  static bool WithinAfternoonHours(int hour) {
+    return hour < DateTimeConstants.HalfDayHourCount;
+  }
+
+  static bool WithinMorningHoursAndNoon(int hour, int min, int sec) {
+    return hour > DateTimeConstants.HalfDayHourCount ||
+        (hour == DateTimeConstants.HalfDayHourCount && (min > 0 || sec > 0));
+  }
+
+  DateTimeResolutionResult ParseBasicRegex(String text, DateTime referenceTime) {
+    var ret = DateTimeResolutionResult();
+    var trimmedText = text.trim();
+
+    // Handle "now"
+    if (config.NowRegex().matchExact(trimmedText, true) != null) {
+      final timex = config.GetMatchedNowTimex(trimmedText);
+      ret.timex = timex;
+      ret.futureValue = ret.pastValue = referenceTime;
+      ret.success = true;
+      return ret;
+    }
+
+    return ret;
+  }
+
+  // Set Resolution of merged entity generated after merging of holiday entity and a time.
+  DateTimeResolutionResult MergeHolidayAndTime(String text, DateTime referenceTime) {
+    var ret = DateTimeResolutionResult();
+
+    var er1 = config.HolidayExtractor().extractDateTime(text, referenceTime);
+
+    if (er1.isEmpty) {
+      er1 = config.HolidayExtractor().extractDateTime(config.TokenBeforeDate() + text, referenceTime);
+      if (er1.length == 1) {
+        er1[0].start -= config.TokenBeforeDate().length;
+      } else {
+        return ret;
+      }
+    } else {
+      // This is to understand if there is an ambiguous token in the text. For some languages (e.g. spanish),
+      // the same word could mean different things (e.g a time in the day or an specific day).
+      if (config.ContainsAmbiguousToken(text, er1[0].text)) {
+        return ret;
+      }
+    }
+
+    var er2 = config.TimeExtractor().extractDateTime(text, referenceTime);
+    if (er2.isEmpty) {
+      // Here we filter out "morning, afternoon, night..." time entities
+      var prefixToken = config.TokenBeforeTime();
+      er2 = config.TimeExtractor().extractDateTime(prefixToken + text, referenceTime);
+
+      if (er2.length == 1) {
+        er2[0].start -= prefixToken.length;
+      } else if (er2.isEmpty) {
+        // check whether there is a number being used as a time point
+        bool hasTimeNumber = false;
+        var numErs = config.integerExtractor().extract(text);
+        if (numErs.isNotEmpty && er1.length == 1) {
+          for (var num in numErs) {
+            var middleBegin = er1[0].start + er1[0].length;
+            var middleEnd = num.start;
+            if (middleBegin > middleEnd) {
+              continue;
+            }
+
+            var middleStr = text.substring(middleBegin, middleEnd).trim();
+            var match = config.DateNumberConnectorRegex().firstMatch(middleStr);
+            if (middleStr.isEmpty || match != null) {
+              num.type = DateTimeConstants.SYS_DATETIME_TIME;
+              er2.add(num);
+              hasTimeNumber = true;
+            }
+          }
+        }
+
+        if (!hasTimeNumber) {
+          return ret;
+        }
+      }
+    }
+
+    var correctTimeIdx = 0;
+    while (correctTimeIdx < er2.length && er2[correctTimeIdx].isOverlap(er1[0])) {
+      correctTimeIdx++;
+    }
+
+    if (correctTimeIdx >= er2.length) {
+      return ret;
+    }
+
+    var pr1 = config.HolidayTimeParser().parseDateTime(er1[0], referenceTime);
+
+    var pr2 = config.TimeParser().parseDateTime(er2[correctTimeIdx], referenceTime);
+    if (pr1.value == null || pr2.value == null) {
+      return ret;
+    }
+
+    var futureDate = (pr1.value as DateTimeResolutionResult).futureValue as DateTime;
+    var pastDate = (pr1.value as DateTimeResolutionResult).pastValue as DateTime;
+    var time = (pr2.value as DateTimeResolutionResult).futureValue as DateTime;
+
+    var hour = time.hour;
+    var min = time.minute;
+    var sec = time.second;
+
+    // Handle morning, afternoon
+    if (config.PMTimeRegex().hasMatch(text) && WithinAfternoonHours(hour)) {
+      hour += DateTimeConstants.HalfDayHourCount;
+    } else if (config.AMTimeRegex().hasMatch(text) && WithinMorningHoursAndNoon(hour, min, sec)) {
+      hour -= DateTimeConstants.HalfDayHourCount;
+    }
+
+    var timeStr = pr2.timexStr ?? '';
+    if (timeStr.endsWith(DateTimeConstants.Comment_AmPm)) {
+      timeStr = timeStr.substring(0, timeStr.length - 4);
+    }
+
+    timeStr = "T${hour.toString().padLeft(2, '0')}${timeStr.substring(3)}";
+    ret.timex = (pr1.timexStr ?? '') + timeStr;
+
+    var val = pr2.value as DateTimeResolutionResult;
+    if (hour <= DateTimeConstants.HalfDayHourCount &&
+        !config.PMTimeRegex().hasMatch(text) &&
+        !config.AMTimeRegex().hasMatch(text) &&
+        val.comment?.isNotEmpty == true) {
+      ret.comment = DateTimeConstants.Comment_AmPm;
+    }
+
+    ret.futureValue = DateUtil.createSafeDate(futureDate.year, futureDate.month, futureDate.day, hour, min, sec);
+    ret.pastValue = DateUtil.createSafeDate(pastDate.year, pastDate.month, pastDate.day, hour, min, sec);
+
+    // Handle case like "on christmas 15:50:06 2016" which year and holiday separated by time.
+    var timeSuffix = text.substring(er2[0].start + er2[0].length);
+    var matchYear = RegExpComposer.getMatchesSimple(config.YearRegex(), timeSuffix).firstOrNull;
+    if (matchYear != null &&
+        ((pr1.value as DateTimeResolutionResult).futureValue as DateTime).year !=
+            ((pr1.value as DateTimeResolutionResult).pastValue as DateTime).year) {
+      var year = (config.DateExtractor() as BaseDateExtractor).getYearFromText(matchYear);
+      var dateSuffix = text.substring(er1[0].start + er1[0].length);
+      var checkYear =
+          config.DateExtractor().getYearFromText(RegExpComposer.getMatchesSimple(config.YearRegex(), dateSuffix).first);
+
+      if (year >= DateTimeConstants.MinYearNum && year <= DateTimeConstants.MaxYearNum && year == checkYear) {
+        ret.futureValue = DateUtil.createSafeDate(year, futureDate.month, futureDate.day, hour, min, sec);
+        ret.pastValue = DateUtil.createSafeDate(year, pastDate.month, pastDate.day, hour, min, sec);
+        ret.timex = year.toString() + (pr1.timexStr ?? '').substring(4) + timeStr;
+      }
+    }
+
+    ret.success = true;
+
+    // Change the value of time object
+    pr2.timexStr = timeStr;
+    if (ret.comment?.isNotEmpty == true) {
+      (pr2.value as DateTimeResolutionResult).comment =
+          ret.comment == DateTimeConstants.Comment_AmPm ? DateTimeConstants.Comment_AmPm : '';
+    }
+
+    // Add the date and time object in case we want to split them
+    ret.subDateTimeEntities = <Object>[pr1, pr2];
+
+    // Add timezone
+    ret.timeZoneResolution = (pr2.value as DateTimeResolutionResult).timeZoneResolution;
+
+    return ret;
+  }
+
+  DateTimeResolutionResult ParseTimeOfToday(String text, DateTime referenceTime) {
+    var ret = DateTimeResolutionResult();
+    var trimmedText = text.trim();
+
+    int hour = 0, min = 0, sec = 0;
+    String timeStr = '';
+
+    var wholeMatch = RegExpComposer.matchExact(config.SimpleTimeOfTodayAfterRegex(), trimmedText, true);
+
+    wholeMatch ??= RegExpComposer.matchExact(config.SimpleTimeOfTodayBeforeRegex(), trimmedText, true);
+
+    if (wholeMatch != null) {
+      var hourStr = wholeMatch.getGroup(DateTimeConstants.HourGroupName).value;
+      if (hourStr.isEmpty) {
+        hourStr = wholeMatch.getGroup("hournum").value;
+        hour = config.Numbers()[hourStr]!;
+      } else {
+        hour = int.parse(hourStr);
+      }
+
+      timeStr = "T${hour.toString().padLeft(2, '0')}";
+    } else {
+      var ers = config.TimeExtractor().extractDateTime(trimmedText, referenceTime);
+      if (ers.length != 1) {
+        var prefixToken = config.TokenBeforeTime();
+        ers = config.TimeExtractor().extractDateTime(prefixToken + trimmedText, referenceTime);
+
+        if (ers.length == 1) {
+          ers[0].start -= prefixToken.length;
+        } else {
+          return ret;
+        }
+      }
+
+      var pr = config.TimeParser().parseDateTime(ers[0], referenceTime);
+      if (pr.value == null) {
+        return ret;
+      }
+
+      // Add timezone
+      ret.timeZoneResolution = (pr.value as DateTimeResolutionResult).timeZoneResolution;
+
+      var time = (pr.value as DateTimeResolutionResult).futureValue as DateTime;
+
+      hour = time.hour;
+      min = time.minute;
+      sec = time.second;
+      timeStr = pr.timexStr ?? '';
+    }
+
+    var match = config.SpecificTimeOfDayRegex().firstMatch(trimmedText);
+
+    if (match != null) {
+      var matchStr = match.input.substring(match.start, match.end);
+
+      // Handle "last", "next"
+      var swift = config.GetSwiftDay(matchStr);
+
+      var date = referenceTime.AddDays(swift);
+
+      // Handle "morning", "afternoon"
+      hour = config.GetHour(matchStr, hour);
+
+      // In this situation, timeStr cannot end up with "ampm", because we always have a "morning" or "night"
+      if (timeStr.endsWith(DateTimeConstants.Comment_AmPm)) {
+        timeStr = timeStr.substring(0, timeStr.length - 4);
+      }
+
+      timeStr = "T${hour.toString().padLeft(2, '0')}${timeStr.substring(3)}";
+
+      ret.timex = DateTimeFormatUtil.formatDate(date) + timeStr;
+      ret.futureValue = ret.pastValue = DateUtil.createSafeDate(date.year, date.month, date.day, hour, min, sec);
+      ret.success = true;
+      return ret;
+    }
+
+    return ret;
+  }
+
+  DateTimeResolutionResult ParseSpecialTimeOfDate(String text, DateTime refDateTime) {
+    var ret = ParseUnspecificTimeOfDate(text, refDateTime);
+
+    if (ret.success) {
+      return ret;
+    }
+
+    var ers = config.DateExtractor().extractDateTime(text, refDateTime);
+    if (ers.length != 1) {
+      return ret;
+    }
+
+    var beforeStr = text.substring(0, ers[0].start);
+    var afterStr = text.substring(ers[0].start + ers[0].length);
+    if (config.SpecificEndOfRegex().hasMatch(beforeStr) || config.SpecificEndOfRegex().hasMatch(afterStr)) {
+      var pr = config.DateParser().parseDateTime(ers[0], refDateTime);
+      var futureDate = (pr.value as DateTimeResolutionResult).futureValue as DateTime;
+      var pastDate = (pr.value as DateTimeResolutionResult).pastValue as DateTime;
+
+      ret = DateTimeFormatUtil.ResolveEndOfDay(pr.timexStr ?? '', futureDate, pastDate);
+    }
+
+    return ret;
+  }
+
+  DateTimeResolutionResult ParseUnspecificTimeOfDate(String text, DateTime refDateTime) {
+    // Handle 'eod', 'end of day'
+    var ret = DateTimeResolutionResult();
+    var eod = config.UnspecificEndOfRegex().firstMatch(text);
+    if (eod != null) {
+      ret = DateTimeFormatUtil.ResolveEndOfDay(DateTimeFormatUtil.formatDate(refDateTime), refDateTime, refDateTime);
+    }
+
+    return ret;
+  }
+
+  // Handle cases like "two hours ago"
+  DateTimeResolutionResult ParserDurationWithAgoAndLater(String text, DateTime referenceTime) {
+    return AgoLaterUtil.ParseDurationWithAgoAndLater(
+        text,
+        referenceTime,
+        config.DurationExtractor(),
+        config.DurationParser(),
+        config.NumberParser(),
+        config.UnitMap(),
+        config.UnitRegex(),
+        config.UtilityConfiguration(),
+        config.GetSwiftDay);
+  }
+}
+
+abstract interface class IDateTimeParserConfiguration extends IDateTimeOptionsConfiguration {
+  String TokenBeforeDate();
+
+  String TokenBeforeTime();
+
+  IDateExtractor DateExtractor();
+
+  IDateTimeExtractor HolidayExtractor();
+
+  IDateTimeExtractor TimeExtractor();
+
+  IDateTimeParser DateParser();
+
+  IDateTimeParser TimeParser();
+
+  IDateTimeParser HolidayTimeParser();
+
+  IExtractor CardinalExtractor();
+
+  IExtractor integerExtractor();
+
+  IParser NumberParser();
+
+  IDateTimeExtractor DurationExtractor();
+
+  IDateTimeParser DurationParser();
+
+  RegExp NowRegex();
+
+  RegExp AMTimeRegex();
+
+  RegExp PMTimeRegex();
+
+  RegExp SimpleTimeOfTodayAfterRegex();
+
+  RegExp SimpleTimeOfTodayBeforeRegex();
+
+  RegExp SpecificTimeOfDayRegex();
+
+  RegExp SpecificEndOfRegex();
+
+  RegExp UnspecificEndOfRegex();
+
+  RegExp UnitRegex();
+
+  RegExp DateNumberConnectorRegex();
+
+  RegExp YearRegex();
+
+  Map<String, String> UnitMap();
+
+  Map<String, int> Numbers();
+
+  IDateTimeUtilityConfiguration UtilityConfiguration();
+
+  bool ContainsAmbiguousToken(String text, String matchedText);
+
+  String? GetMatchedNowTimex(String text);
+
+  int GetSwiftDay(String text);
+
+  int GetHour(String text, int hour);
+}

--- a/lib/src/date_time/base_time_extractor.dart
+++ b/lib/src/date_time/base_time_extractor.dart
@@ -1,0 +1,143 @@
+import 'package:nlp/src/core/extraction.dart';
+import 'package:nlp/src/date_time/base_date_extractor.dart';
+import 'package:nlp/src/date_time/constants.dart';
+import 'package:nlp/src/date_time/date_time_extraction.dart';
+import 'package:nlp/src/date_time/extract_result_extension.dart';
+import 'package:nlp/src/date_time/timezone_utility.dart';
+import 'package:nlp/src/duration/duration.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class BaseTimeExtractor implements IDateTimeExtractor {
+  BaseTimeExtractor(this.config);
+
+  final ITimeExtractorConfiguration config;
+
+  @override
+  String getExtractorName() {
+    return DateTimeConstants.SYS_DATETIME_TIME;
+  }
+
+  @override
+  List<ExtractResult> extract(String input) {
+    return extractDateTime(input, DateTime.now());
+  }
+
+  @override
+  List<ExtractResult> extractDateTime(String input, DateTime reference) {
+    final normalizedInput = input.toLowerCase();
+
+    var tokens = <Token>[];
+    tokens.addAll(BasicRegexMatch(normalizedInput));
+    tokens.addAll(AtRegexMatch(normalizedInput));
+    tokens.addAll(BeforeAfterRegexMatch(normalizedInput));
+    tokens.addAll(SpecialCasesRegexMatch(normalizedInput, reference));
+
+    var timeErs = Token.mergeAllTokens(tokens, normalizedInput, getExtractorName());
+
+    if (config.options.match(DateTimeOptions.EnablePreview)) {
+      timeErs = TimeZoneUtility.MergeTimeZones(
+          timeErs, config.TimeZoneExtractor().extractDateTime(normalizedInput, reference), normalizedInput);
+    }
+
+    // Remove common ambiguous cases
+    timeErs = ExtractResultExtension.FilterAmbiguity(timeErs, normalizedInput, config.AmbiguityFiltersDict());
+
+    return timeErs;
+  }
+
+  List<Token> BasicRegexMatch(String text) {
+    var results = <Token>[];
+
+    for (var regex in config.TimeRegexList()) {
+      var matches = RegExpComposer.getMatchesSimple(regex, text);
+
+      for (final match in matches) {
+        // @TODO Workaround to avoid incorrect partial-only matches. Remove after time regex reviews across languages.
+        var lth = match.getGroup("lth").value;
+
+        if (lth.isEmpty ||
+            (lth.length != match.length && !(match.length == lth.length + 1 && match.value.endsWith(" ")))) {
+          results.add(Token(match.index, match.index + match.length));
+        }
+      }
+    }
+
+    return results;
+  }
+
+  List<Token> AtRegexMatch(String text) {
+    var result = <Token>[];
+
+    // handle "at 5", "at seven"
+    if (config.AtRegex().hasMatch(text)) {
+      var matches = config.AtRegex().allMatches(text);
+      for (Match match in matches) {
+        if (match.end - match.start + 1 < text.length && text[match.end - 1] == '%') {
+          continue;
+        }
+
+        result.add(Token(match.start, match.end));
+      }
+    }
+
+    return result;
+  }
+
+  List<Token> BeforeAfterRegexMatch(String text) {
+    var result = <Token>[];
+
+    // only enabled in CalendarMode
+    if (config.options.match(DateTimeOptions.CalendarMode)) {
+      // handle "before 3", "after three"
+      var beforeAfterRegex = config.TimeBeforeAfterRegex();
+      if (beforeAfterRegex.hasMatch(text)) {
+        var matches = beforeAfterRegex.allMatches(text);
+        for (Match match in matches) {
+          result.add(Token(match.start, match.end));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  List<Token> SpecialCasesRegexMatch(String text, DateTime reference) {
+    var result = <Token>[];
+
+    // handle "ish"
+    if (config.IshRegex().hasMatch(text)) {
+      var matches = config.IshRegex().allMatches(text);
+
+      for (Match match in matches) {
+        result.add(Token(match.start, match.end));
+      }
+    }
+
+    return result;
+  }
+
+  // public static readonly Regex HourRegex =
+  //     new Regex(BaseDateTime.HourRegex, RegexOptions.Singleline | RegexOptions.Compiled, RegexTimeOut);
+
+  // public static readonly Regex MinuteRegex =
+  //     new Regex(BaseDateTime.MinuteRegex, RegexOptions.Singleline | RegexOptions.Compiled, RegexTimeOut);
+
+  // public static readonly Regex SecondRegex =
+  //     new Regex(BaseDateTime.SecondRegex, RegexOptions.Singleline | RegexOptions.Compiled, RegexTimeOut);
+}
+
+abstract interface class ITimeExtractorConfiguration extends IDateTimeOptionsConfiguration {
+  IDateTimeExtractor TimeZoneExtractor();
+
+  List<RegExp> TimeRegexList();
+
+  RegExp AtRegex();
+
+  RegExp IshRegex();
+
+  RegExp TimeBeforeAfterRegex();
+
+  RegExp TimeTokenPrefix();
+
+  Map<RegExp, RegExp> AmbiguityFiltersDict();
+}

--- a/lib/src/date_time/base_time_parser.dart
+++ b/lib/src/date_time/base_time_parser.dart
@@ -1,0 +1,315 @@
+import 'package:nlp/src/core/extraction.dart';
+import 'package:nlp/src/core/parser.dart';
+import 'package:nlp/src/date_time/base_date_extractor.dart';
+import 'package:nlp/src/date_time/constants.dart';
+import 'package:nlp/src/date_time/date_time_format_util.dart';
+import 'package:nlp/src/date_time/date_time_parsing.dart';
+import 'package:nlp/src/date_time/date_time_recognizer.dart';
+import 'package:nlp/src/date_time/date_util.dart';
+import 'package:nlp/src/date_time/datetime_utility_configuration.dart';
+import 'package:nlp/src/date_time/timezone_utility.dart';
+import 'package:nlp/src/duration/base_duration_parser.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class BaseTimeParser implements IDateTimeParser {
+  BaseTimeParser(this.config);
+
+  final ITimeParserConfiguration config;
+
+  @override
+  List<DateTimeParseResult> filterResults(String query, List<DateTimeParseResult> candidateResults) => candidateResults;
+
+  @override
+  String getParserName() => DateTimeConstants.SYS_DATETIME_TIME;
+
+  @override
+  ParseResult? parse(ExtractResult extractResult) {
+    return parseDateTime(extractResult, DateTime.now());
+  }
+
+  @override
+  DateTimeParseResult parseDateTime(ExtractResult er, DateTime reference) {
+    Object? value;
+    if (er.type == getParserName()) {
+      DateTimeResolutionResult innerResult;
+
+      // Resolve timezone
+      if (TimeZoneUtility.ShouldResolveTimeZone(er, config.options)) {
+        var metadata = er.data as Map<String, Object>;
+        var timezoneEr = metadata[DateTimeConstants.SYS_DATETIME_TIMEZONE] as ExtractResult;
+        var timezonePr = config.TimeZoneParser().parse(timezoneEr);
+
+        innerResult = InternalParse(er.text.substring(0, (er.text.length - timezoneEr.length)), reference);
+
+        if (timezonePr != null && timezonePr.value != null) {
+          innerResult.timeZoneResolution = (timezonePr.value as DateTimeResolutionResult).timeZoneResolution;
+        }
+      } else {
+        innerResult = InternalParse(er.text, reference);
+      }
+
+      if (innerResult.success) {
+        innerResult.futureResolution = <String, String>{
+          TimeTypeConstants.TIME: DateTimeFormatUtil.formatTime(innerResult.futureValue as DateTime),
+        };
+
+        innerResult.pastResolution = <String, String>{
+          TimeTypeConstants.TIME: DateTimeFormatUtil.formatTime(innerResult.pastValue as DateTime),
+        };
+
+        value = innerResult;
+      }
+    }
+
+    var ret = DateTimeParseResult(
+      text: er.text,
+      start: er.start,
+      length: er.length,
+      type: er.type,
+      data: er.data,
+      value: value,
+      timexStr: value == null ? '' : (value as DateTimeResolutionResult).timex,
+      resolutionStr: '',
+    );
+
+    return ret;
+  }
+
+  DateTimeResolutionResult InternalParse(String text, DateTime referenceTime) {
+    var innerResult = ParseBasicRegexMatch(text, referenceTime);
+    return innerResult;
+  }
+
+  // parse basic patterns in TimeRegexList
+  DateTimeResolutionResult ParseBasicRegexMatch(String text, DateTime referenceTime) {
+    var trimmedText = text.trim();
+    var offset = 0;
+
+    var match = RegExpComposer.getMatchesSimple(config.AtRegex(), trimmedText).firstOrNull;
+
+    if (match == null) {
+      match = RegExpComposer.getMatchesSimple(config.AtRegex(), config.TimeTokenPrefix() + trimmedText).firstOrNull;
+      offset = config.TimeTokenPrefix().length;
+    }
+
+    if (match != null && match.index == offset && match.length == trimmedText.length) {
+      return Match2Time(match, referenceTime);
+    }
+
+    // parse hour pattern, like "twenty one", "16"
+    // create a extract result which content the pass-in text
+    int? hour = config.Numbers()[text] ?? int.tryParse(text);
+    if (hour != null) {
+      if (hour >= 0 && hour <= 24) {
+        var ret = DateTimeResolutionResult();
+
+        if (hour == 24) {
+          hour = 0;
+        }
+
+        if (hour <= DateTimeConstants.HalfDayHourCount && hour != 0) {
+          ret.comment = DateTimeConstants.Comment_AmPm;
+        }
+
+        ret.timex = "T${hour.toString().padLeft(2, '0')}";
+        ret.futureValue = ret.pastValue =
+            DateUtil.createSafeDate(referenceTime.year, referenceTime.month, referenceTime.day, hour, 0, 0);
+        ret.success = true;
+        return ret;
+      }
+    }
+
+    var regexes = config.TimeRegexes();
+
+    for (var regex in regexes) {
+      var exactMatch = RegExpComposer.matchExact(regex, trimmedText, true);
+
+      if (exactMatch != null) {
+        return Match2Time(exactMatch, referenceTime);
+      }
+    }
+
+    return DateTimeResolutionResult();
+  }
+
+  DateTimeResolutionResult Match2Time(NlpMatch match, DateTime referenceTime) {
+    var ret = DateTimeResolutionResult();
+    bool hasMin = false, hasSec = false, hasAm = false, hasPm = false, hasMid = false;
+    int hour = 0, min = 0, second = 0, day = referenceTime.day, month = referenceTime.month, year = referenceTime.year;
+
+    var writtenTimeStr = match.getGroup("writtentime").value;
+
+    if (writtenTimeStr.isNotEmpty) {
+      // get hour
+      var hourStr = match.getGroup("hournum").value;
+      hour = config.Numbers()[hourStr]!;
+
+      // get minute
+      var minStr = match.getGroup("minnum").value;
+      var tensStr = match.getGroup("tens").value;
+
+      if (minStr.isNotEmpty) {
+        min = config.Numbers()[minStr]!;
+        if (tensStr.isNotEmpty) {
+          min += config.Numbers()[tensStr]!;
+        }
+
+        hasMin = true;
+      }
+    } else if (match.getGroup("mid").value.isNotEmpty) {
+      hasMid = true;
+      if (match.getGroup("midnight").value.isNotEmpty) {
+        hour = 0;
+        min = 0;
+        second = 0;
+      } else if (match.getGroup("midearlymorning").value.isNotEmpty) {
+        hour = 6;
+        min = 0;
+        second = 0;
+      } else if (match.getGroup("midmorning").value.isNotEmpty) {
+        hour = 10;
+        min = 0;
+        second = 0;
+      } else if (match.getGroup("midafternoon").value.isNotEmpty) {
+        hour = 14;
+        min = 0;
+        second = 0;
+      } else if (match.getGroup("midday").value.isNotEmpty) {
+        hour = DateTimeConstants.HalfDayHourCount;
+        min = 0;
+        second = 0;
+      }
+    } else {
+      // get hour
+      var hourStr = match.getGroup(DateTimeConstants.HourGroupName).value;
+      if (hourStr.isEmpty) {
+        hourStr = match.getGroup("hournum").value;
+
+        if (!config.Numbers().containsKey(hourStr)) {
+          return ret;
+        }
+
+        hour = config.Numbers()[hourStr]!;
+      } else {
+        final newHour = int.tryParse(hourStr);
+        if (newHour == null) {
+          if (!config.Numbers().containsKey(hourStr)) {
+            return ret;
+          }
+          hour = config.Numbers()[hourStr]!;
+        } else {
+          hour = newHour;
+        }
+      }
+
+      // get minute
+      var minStr = match.getGroup(DateTimeConstants.MinuteGroupName).value;
+      if (minStr.isEmpty) {
+        minStr = match.getGroup("minnum").value;
+        if (minStr.isNotEmpty) {
+          min = config.Numbers()[minStr]!;
+          hasMin = true;
+        }
+
+        var tensStr = match.getGroup("tens").value;
+        if (tensStr.isNotEmpty) {
+          min += config.Numbers()[tensStr]!;
+          hasMin = true;
+        }
+      } else {
+        min = int.parse(minStr);
+        hasMin = true;
+      }
+
+      // get second
+      var secStr = match.getGroup(DateTimeConstants.SecondGroupName).value;
+      if (secStr.isNotEmpty) {
+        second = int.parse(secStr);
+        hasSec = true;
+      } else {
+        // as for minStr, check if secStr is defined in Numbers
+        secStr = match.getGroup("secnum").value;
+        if (secStr.isNotEmpty) {
+          second = config.Numbers()[secStr]!;
+          hasSec = true;
+        }
+      }
+    }
+
+    // Adjust by desc string
+    var descStr = match.getGroup(DateTimeConstants.DescGroupName).value;
+
+    // ampm is a special case in which at 6ampm = at 6
+    if (config.UtilityConfiguration().amDescRegExp().hasMatch(descStr) ||
+        config.UtilityConfiguration().amPmDescRegExp().hasMatch(descStr) ||
+        match.getGroup(DateTimeConstants.ImplicitAmGroupName).value.isNotEmpty) {
+      if (hour >= DateTimeConstants.HalfDayHourCount) {
+        hour -= DateTimeConstants.HalfDayHourCount;
+      }
+
+      if (!config.UtilityConfiguration().amPmDescRegExp().hasMatch(descStr)) {
+        hasAm = true;
+      }
+    } else if (config.UtilityConfiguration().pmDescRegExp().hasMatch(descStr) ||
+        match.getGroup(DateTimeConstants.ImplicitPmGroupName).value.isNotEmpty) {
+      if (hour < DateTimeConstants.HalfDayHourCount) {
+        hour += DateTimeConstants.HalfDayHourCount;
+      }
+
+      hasPm = true;
+    }
+
+    // adjust min by prefix
+    var timePrefix = match.getGroup(DateTimeConstants.PrefixGroupName).value;
+    if (timePrefix.isNotEmpty) {
+      (hour, min, hasMin) = config.AdjustByPrefix(timePrefix, hour, min, hasMin);
+    }
+
+    // adjust hour by suffix
+    var timeSuffix = match.getGroup(DateTimeConstants.SuffixGroupName).value;
+    if (timeSuffix.isNotEmpty) {
+      (hour, min, hasMin, hasAm, hasPm) = config.AdjustBySuffix(timeSuffix, hour, min, hasMin, hasAm, hasPm);
+    }
+
+    if (hour == 24) {
+      hour = 0;
+    }
+
+    ret.timex = "T${hour.toString().padLeft(2, '0')}";
+    if (hasMin) {
+      ret.timex = "${ret.timex!}:${min.toString().padLeft(2, '0')}";
+    }
+
+    if (hasSec) {
+      ret.timex = "${ret.timex!}:${second.toString().padLeft(2, '0')}";
+    }
+
+    if (hour <= DateTimeConstants.HalfDayHourCount && hour != 0 && !hasPm && !hasAm && !hasMid) {
+      ret.comment = DateTimeConstants.Comment_AmPm;
+    }
+
+    ret.futureValue = ret.pastValue = DateUtil.createSafeDate(year, month, day, hour, min, second);
+    ret.success = true;
+
+    return ret;
+  }
+}
+
+abstract interface class ITimeParserConfiguration extends IDateTimeOptionsConfiguration {
+  String TimeTokenPrefix();
+
+  RegExp AtRegex();
+
+  List<RegExp> TimeRegexes();
+
+  Map<String, int> Numbers();
+
+  IDateTimeUtilityConfiguration UtilityConfiguration();
+
+  IDateTimeParser TimeZoneParser();
+
+  (int hour, int min, bool hasMin) AdjustByPrefix(String prefix, int hour, int min, bool hasMin);
+
+  (int hour, int min, bool hasMin, bool hasAm, bool hasPm) AdjustBySuffix(
+      String suffix, int hour, int min, bool hasMin, bool hasAm, bool hasPm);
+}

--- a/lib/src/date_time/constants.dart
+++ b/lib/src/date_time/constants.dart
@@ -120,6 +120,9 @@ class DateTimeConstants {
   // hours of a half mid-day-duration
   static const int HalfMidDayDurationHourCount = 2;
 
+  // Hours in a quarter of a day
+  static const int QuarterDayHourCount = 6;
+
   // the length of four digits year, e.g., 2018
   static const int FourDigitsYearLength = 4;
 

--- a/lib/src/date_time/date_time_format_util.dart
+++ b/lib/src/date_time/date_time_format_util.dart
@@ -78,25 +78,29 @@ class DateTimeFormatUtil {
   //   return luisTime(hour, min, Constants.InvalidSecond);
   // }
   //
-  // public static String luisTime(int hour, int min, int second) {
+  static String luisTimeFromComponents(int hour, int min, int second) {
+    String result;
+    if (second == DateTimeConstants.InvalidSecond) {
+      result =
+          [hour.toString().padLeft(2, '0'), min.toString().padLeft(2, '0')].join(DateTimeConstants.TimeTimexConnector);
+    } else {
+      result = [hour.toString().padLeft(2, '0'), min.toString().padLeft(2, '0'), second.toString().padLeft(2, '0')]
+          .join(DateTimeConstants.TimeTimexConnector);
+    }
+
+    return result;
+  }
+
   //
-  //   String result;
-  //   if (second == Constants.InvalidSecond) {
-  //     result = String.join(Constants.TimeTimexConnector, String.format("%02d", hour), String.format("%02d", min));
-  //   } else {
-  //     result = String.join(Constants.TimeTimexConnector, String.format("%02d", hour), String.format("%02d", min), String.format("%02d", second));
-  //   }
+  static String luisTime(DateTime time) {
+    return luisTimeFromComponents(time.hour, time.minute, time.second);
+  }
+
   //
-  //   return result;
-  // }
-  //
-  // public static String luisTime(LocalDateTime time) {
-  //   return luisTime(time.getHour(), time.getMinute(), time.getSecond());
-  // }
-  //
-  // public static String luisDateTime(LocalDateTime time) {
-  //   return luisDate(time) + "T" + luisTime(time.getHour(), time.getMinute(), time.getSecond());
-  // }
+  static String luisDateTime(DateTime time) {
+    return "${luisDateFromDateTime(time)}T${luisTime(time)}";
+  }
+
   //
   static String formatDate(DateTime date) {
     return [
@@ -119,6 +123,17 @@ class DateTimeFormatUtil {
       formatDate(datetime),
       formatTime(datetime),
     ].join(" ");
+  }
+
+  static DateTimeResolutionResult ResolveEndOfDay(String timexPrefix, DateTime futureDate, DateTime pastDate) {
+    var ret = DateTimeResolutionResult();
+
+    ret.timex = "${timexPrefix}T23:59:59";
+    ret.futureValue = futureDate.dateOnly.AddDays(1).AddSeconds(-1);
+    ret.pastValue = pastDate.dateOnly.AddDays(1).AddSeconds(-1);
+    ret.success = true;
+
+    return ret;
   }
 
   //

--- a/lib/src/date_time/date_util.dart
+++ b/lib/src/date_time/date_util.dart
@@ -26,7 +26,8 @@ class DateUtil {
     return DateTime.tryParse('$yearStr-$monthStr-$dayStr') != null;
   }
 
-  static DateTime createSafeDate(int year, int month, int day) {
+  static DateTime createSafeDate(int year, int month, int day,
+      [int hour = 0, int minute = 0, int second = 0, int millisecond = 0]) {
     if (year < 1 || year > 9999) {
       return minValue();
     }
@@ -36,7 +37,7 @@ class DateUtil {
         : _monthValidDays[month - 1];
 
     if (month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth) {
-      return DateTime(year, month, day);
+      return DateTime(year, month, day, hour, minute, second, millisecond);
     }
 
     return minValue();

--- a/lib/src/date_time/english/english_date_time_extractor_configuration.dart
+++ b/lib/src/date_time/english/english_date_time_extractor_configuration.dart
@@ -1,0 +1,96 @@
+import 'package:nlp/src/core/extraction.dart';
+import 'package:nlp/src/date_time/base_date_extractor.dart';
+import 'package:nlp/src/date_time/base_datetime_extractor.dart';
+import 'package:nlp/src/date_time/date_time_extraction.dart';
+import 'package:nlp/src/date_time/datetime_utility_configuration.dart';
+import 'package:nlp/src/date_time/english/english_date_time_utility_configuration.dart';
+import 'package:nlp/src/date_time/english_date_extractor.dart';
+import 'package:nlp/src/date_time/english_date_time.dart';
+import 'package:nlp/src/date_time/english_date_time_parser.dart';
+import 'package:nlp/src/duration/duration.dart';
+import 'package:nlp/src/duration/duration_extractor.dart';
+import 'package:nlp/src/numbers/numbers.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class EnglishDateTimeExtractorConfiguration extends BaseOptionsConfiguration
+    implements IDateTimeExtractorConfiguration {
+  EnglishDateTimeExtractorConfiguration(this.config, [super.options = DateTimeOptions.None])
+      : _datePointExtractor = BaseDateExtractor(EnglishDateExtractorConfiguration(config));
+
+  final ICommonDateTimeParserConfiguration config;
+
+  @override
+  RegExp DateNumberConnectorRegExp() =>
+      RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.DateNumberConnectorRegex);
+
+  final IDateExtractor _datePointExtractor;
+  @override
+  IDateExtractor DatePointExtractor() => _datePointExtractor;
+
+  @override
+  IDateTimeExtractor DurationExtractor() => config.durationExtractor;
+
+  @override
+  IDateTimeExtractor HolidayExtractor() => config.holidayExtractor;
+
+  @override
+  IExtractor integerExtractor() => IntegerExtractor.getInstance();
+
+  @override
+  bool IsConnector(String text) {
+    text = text.trim();
+    return text.isEmpty ||
+        RegExp(EnglishDateTime.PrepositionRegex).hasMatch(text) ||
+        RegExp(EnglishDateTime.ConnectorRegex).hasMatch(text);
+  }
+
+  @override
+  RegExp NowRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.NowRegex);
+
+  @override
+  RegExp NumberAsTimeRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.NumberAsTimeRegex);
+
+  @override
+  RegExp SimpleTimeOfTodayAfterRegExp() =>
+      RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SimpleTimeOfTodayAfterRegex);
+
+  @override
+  RegExp SimpleTimeOfTodayBeforeRegExp() =>
+      RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SimpleTimeOfTodayBeforeRegex);
+
+  @override
+  RegExp SpecificEndOfRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SpecificEndOfRegex);
+
+  @override
+  RegExp SuffixAfterRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SuffixAfterRegex);
+
+  @override
+  RegExp SuffixRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SuffixRegex);
+
+  @override
+  RegExp TimeOfDayRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeOfDayRegex);
+
+  @override
+  RegExp TimeOfTodayAfterRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeOfTodayAfterRegex);
+
+  @override
+  RegExp TimeOfTodayBeforeRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeOfTodayBeforeRegex);
+
+  @override
+  IDateTimeExtractor TimePointExtractor() => config.timeExtractor;
+
+  @override
+  RegExp UnitRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeUnitRegex);
+
+  @override
+  RegExp UnspecificEndOfRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.UnspecificEndOfRegex);
+
+  @override
+  IDateTimeUtilityConfiguration UtilityConfiguration() => EnglishDatetimeUtilityConfiguration();
+
+  @override
+  RegExp YearRegExp() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.YearRegex);
+
+  @override
+  RegExp YearSuffix() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.YearSuffix);
+}

--- a/lib/src/date_time/english/english_date_time_parser_configuration.dart
+++ b/lib/src/date_time/english/english_date_time_parser_configuration.dart
@@ -1,0 +1,170 @@
+import 'package:nlp/src/core/extraction.dart';
+import 'package:nlp/src/core/parser.dart';
+import 'package:nlp/src/date_time/base_datetime_options_configuration.dart';
+import 'package:nlp/src/date_time/base_datetime_parser.dart';
+import 'package:nlp/src/date_time/constants.dart';
+import 'package:nlp/src/date_time/date_time_extraction.dart';
+import 'package:nlp/src/date_time/date_time_parsing.dart';
+import 'package:nlp/src/date_time/datetime_utility_configuration.dart';
+import 'package:nlp/src/date_time/english/english_date_time_utility_configuration.dart';
+import 'package:nlp/src/date_time/english/english_holiday_extractor_configuration.dart';
+import 'package:nlp/src/date_time/english_date_time.dart';
+import 'package:nlp/src/date_time/english_date_time_parser.dart';
+import 'package:nlp/src/duration/duration.dart';
+import 'package:nlp/src/numbers/numbers.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class EnglishDateTimeParserConfiguration extends BaseDateTimeOptionsConfiguration
+    implements IDateTimeParserConfiguration {
+  EnglishDateTimeParserConfiguration(this.config, {super.options = DateTimeOptions.None});
+
+  final ICommonDateTimeParserConfiguration config;
+
+  @override
+  RegExp AMTimeRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.AMTimeRegex);
+
+  @override
+  IExtractor CardinalExtractor() => config.cardinalExtractor;
+
+  @override
+  bool ContainsAmbiguousToken(String text, String matchedText) => false;
+
+  @override
+  IDateExtractor DateExtractor() => config.dateExtractor;
+
+  @override
+  RegExp DateNumberConnectorRegex() =>
+      RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.DateNumberConnectorRegex);
+
+  @override
+  IDateTimeParser DateParser() => config.dateParser;
+
+  @override
+  IDateTimeExtractor DurationExtractor() => config.durationExtractor;
+
+  @override
+  IDateTimeParser DurationParser() => config.durationParser;
+
+  @override
+  int GetHour(String text, int hour) {
+    int result = hour;
+
+    var trimmedText = text.trim();
+
+    if (AMTimeRegex().matchEnd(trimmedText, true) != null && hour >= DateTimeConstants.HalfDayHourCount) {
+      result -= DateTimeConstants.HalfDayHourCount;
+    } else if (AMTimeRegex().matchEnd(trimmedText, true) == null &&
+        hour < DateTimeConstants.HalfDayHourCount &&
+        !(NightTimeRegex().matchEnd(trimmedText, true) != null && hour < DateTimeConstants.QuarterDayHourCount)) {
+      result += DateTimeConstants.HalfDayHourCount;
+    }
+
+    return result;
+  }
+
+  @override
+  String? GetMatchedNowTimex(String text) {
+    var trimmedText = text.trim();
+
+    if (NowTimeRegex().matchEnd(trimmedText, true) != null) {
+      return "PRESENT_REF";
+    } else if (RecentlyTimeRegex().matchExact(trimmedText, true) != null) {
+      return "PAST_REF";
+    } else if (AsapTimeRegex().matchExact(trimmedText, true) != null) {
+      return "FUTURE_REF";
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  int GetSwiftDay(String text) {
+    var trimmedText = text.trim();
+
+    var swift = 0;
+    if (NextPrefixRegex().matchBegin(trimmedText, true) != null) {
+      swift = 1;
+    } else if (PreviousPrefixRegex().matchBegin(trimmedText, true) != null) {
+      swift = -1;
+    }
+
+    return swift;
+  }
+
+  @override
+  IDateTimeExtractor HolidayExtractor() => config.holidayExtractor;
+
+  @override
+  IDateTimeParser HolidayTimeParser() {
+    // TODO: implement HolidayTimeParser
+    throw UnimplementedError();
+  }
+
+  @override
+  IExtractor integerExtractor() => IntegerExtractor.getInstance();
+
+  @override
+  RegExp NowRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.NowRegex);
+
+  @override
+  IParser NumberParser() => config.numberParser;
+
+  @override
+  Map<String, int> Numbers() => config.numbers;
+
+  @override
+  RegExp PMTimeRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.PMTimeRegex);
+
+  @override
+  RegExp SimpleTimeOfTodayAfterRegex() =>
+      RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SimpleTimeOfTodayAfterRegex);
+
+  @override
+  RegExp SimpleTimeOfTodayBeforeRegex() =>
+      RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SimpleTimeOfTodayBeforeRegex);
+
+  @override
+  RegExp SpecificEndOfRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SpecificEndOfRegex);
+
+  @override
+  RegExp SpecificTimeOfDayRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.SpecificTimeOfDayRegex);
+
+  @override
+  IDateTimeExtractor TimeExtractor() => config.timeExtractor;
+
+  @override
+  IDateTimeParser TimeParser() => config.timeParser;
+
+  @override
+  String TokenBeforeDate() => EnglishDateTime.TokenBeforeDate;
+
+  @override
+  String TokenBeforeTime() => EnglishDateTime.TokenBeforeTime;
+
+  @override
+  Map<String, String> UnitMap() => config.unitMap;
+
+  @override
+  RegExp UnitRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeUnitRegex);
+
+  @override
+  RegExp UnspecificEndOfRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.UnspecificEndOfRegex);
+
+  @override
+  IDateTimeUtilityConfiguration UtilityConfiguration() => EnglishDatetimeUtilityConfiguration();
+
+  @override
+  RegExp YearRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.YearRegex);
+
+  RegExp NightTimeRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.NightTimeRegex);
+
+  RegExp NowTimeRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.NowTimeRegex);
+
+  RegExp RecentlyTimeRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.RecentlyTimeRegex);
+
+  RegExp AsapTimeRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.AsapTimeRegex);
+
+  RegExp NextPrefixRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.NextPrefixRegex);
+
+  RegExp PreviousPrefixRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.PreviousPrefixRegex);
+}

--- a/lib/src/date_time/english/english_time_extractor_configuration.dart
+++ b/lib/src/date_time/english/english_time_extractor_configuration.dart
@@ -1,0 +1,72 @@
+import 'package:nlp/src/core/definition_loader.dart';
+import 'package:nlp/src/date_time/base_datetime_options_configuration.dart';
+import 'package:nlp/src/date_time/base_time_extractor.dart';
+import 'package:nlp/src/date_time/date_time_extraction.dart';
+import 'package:nlp/src/date_time/english_date_time.dart';
+import 'package:nlp/src/date_time/english_date_time_parser.dart';
+import 'package:nlp/src/duration/duration.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class EnglishTimeExtractorConfiguration extends BaseDateTimeOptionsConfiguration
+    implements ITimeExtractorConfiguration {
+  EnglishTimeExtractorConfiguration(this.config, {super.options = DateTimeOptions.None});
+
+  final ICommonDateTimeParserConfiguration config;
+
+  @override
+  Map<RegExp, RegExp> AmbiguityFiltersDict() =>
+      DefinitionLoader.LoadAmbiguityFilters(EnglishDateTime.AmbiguityDurationFiltersDict);
+
+  @override
+  RegExp AtRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.AtRegex);
+
+  @override
+  RegExp IshRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.IshRegex);
+
+  @override
+  RegExp TimeBeforeAfterRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeBeforeAfterRegex);
+
+  @override
+  List<RegExp> TimeRegexList() => [
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex1),
+
+        // (three min past)? 3:00(:00)? (pm)?
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex2),
+
+        // (three min past)? 3.00 (pm)
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex3),
+
+        // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex4),
+
+        // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex5),
+
+        // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex6),
+
+        // (in the night) at? (five thirty|seven|7|7:00(:00)?) (pm)?
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex7),
+
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex9),
+
+        // (three min past)? 3h00 (pm)?
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex10),
+
+        // at 2.30, "at" prefix is required here
+        // 3.30pm, "am/pm" suffix is required here
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeRegex11),
+
+        // 340pm
+        RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.ConnectNumRegex),
+      ];
+
+  @override
+  RegExp TimeTokenPrefix() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeTokenPrefix);
+
+  @override
+  IDateTimeExtractor TimeZoneExtractor() {
+    // TODO: implement TimeZoneExtractor
+    throw UnimplementedError();
+  }
+}

--- a/lib/src/date_time/english/english_time_extractor_configuration.dart
+++ b/lib/src/date_time/english/english_time_extractor_configuration.dart
@@ -69,4 +69,6 @@ class EnglishTimeExtractorConfiguration extends BaseDateTimeOptionsConfiguration
     // TODO: implement TimeZoneExtractor
     throw UnimplementedError();
   }
+
+  static RegExp LessThanOneHour() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.LessThanOneHour);
 }

--- a/lib/src/date_time/english/english_time_parser_configuration.dart
+++ b/lib/src/date_time/english/english_time_parser_configuration.dart
@@ -1,0 +1,156 @@
+import 'package:nlp/src/date_time/base_datetime_options_configuration.dart';
+import 'package:nlp/src/date_time/base_time_parser.dart';
+import 'package:nlp/src/date_time/constants.dart';
+import 'package:nlp/src/date_time/date_time_parsing.dart';
+import 'package:nlp/src/date_time/datetime_utility_configuration.dart';
+import 'package:nlp/src/date_time/english/english_date_time_utility_configuration.dart';
+import 'package:nlp/src/date_time/english/english_time_extractor_configuration.dart';
+import 'package:nlp/src/date_time/english_date_time.dart';
+import 'package:nlp/src/date_time/english_date_time_parser.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class EnglishTimeParserConfiguration extends BaseDateTimeOptionsConfiguration implements ITimeParserConfiguration {
+  EnglishTimeParserConfiguration(this.config, {required super.options});
+
+  final ICommonDateTimeParserConfiguration config;
+
+  @override
+  (int hour, int min, bool hasMin) AdjustByPrefix(String prefix, int hour, int min, bool hasMin) {
+    int deltaMin;
+
+    var trimedPrefix = prefix.trim();
+
+    if (HalfTokenRegex().hasMatch(trimedPrefix)) {
+      deltaMin = 30;
+    } else if (QuarterTokenRegex().hasMatch(trimedPrefix)) {
+      deltaMin = 15;
+    } else if (ThreeQuarterTokenRegex().hasMatch(trimedPrefix)) {
+      deltaMin = 45;
+    } else {
+      var match =
+          RegExpComposer.getMatchesSimple(EnglishTimeExtractorConfiguration.LessThanOneHour(), trimedPrefix).first;
+      var minStr = match.getGroup("deltamin").value;
+      if (minStr.isNotEmpty) {
+        deltaMin = int.parse(minStr);
+      } else {
+        minStr = match.getGroup("deltaminnum").value;
+        deltaMin = Numbers()[minStr]!;
+      }
+    }
+
+    if (ToTokenRegex().hasMatch(trimedPrefix)) {
+      deltaMin = -deltaMin;
+    }
+
+    int adjustedMin = min;
+    int adjustedHour = hour;
+
+    adjustedMin += deltaMin;
+    if (adjustedMin < 0) {
+      adjustedMin += 60;
+      adjustedHour -= 1;
+    }
+
+    return (adjustedHour, adjustedMin, true);
+  }
+
+  @override
+  (int hour, int min, bool hasMin, bool hasAm, bool hasPm) AdjustBySuffix(
+      String suffix, int hour, int min, bool hasMin, bool hasAm, bool hasPm) {
+    var deltaHour = 0;
+    var match = RegExpComposer.matchExact(TimeSuffixFull(), suffix, true);
+
+    bool adjustedHasAm = hasAm;
+    bool adjustedHasPm = hasPm;
+    bool adjustedHasMin = hasMin;
+
+    int adjustedHour = hour;
+    int adjustedMin = min;
+
+    if (match != null) {
+      var oclockStr = match.getGroup("oclock").value;
+      if (oclockStr.isEmpty) {
+        var matchAmStr = match.getGroup(DateTimeConstants.AmGroupName).value;
+        if (matchAmStr.isNotEmpty) {
+          if (hour >= DateTimeConstants.HalfDayHourCount) {
+            deltaHour = -DateTimeConstants.HalfDayHourCount;
+          } else {
+            adjustedHasAm = true;
+          }
+        }
+
+        var matchPmStr = match.getGroup(DateTimeConstants.PmGroupName).value;
+        if (matchPmStr.isNotEmpty) {
+          if (hour < DateTimeConstants.HalfDayHourCount) {
+            deltaHour = DateTimeConstants.HalfDayHourCount;
+          }
+
+          if (LunchRegex().hasMatch(matchPmStr)) {
+            if (hour >= 10 && hour <= DateTimeConstants.HalfDayHourCount) {
+              deltaHour = 0;
+              if (hour == DateTimeConstants.HalfDayHourCount) {
+                adjustedHasPm = true;
+              } else {
+                adjustedHasAm = true;
+              }
+            } else {
+              adjustedHasPm = true;
+            }
+          } else if (NightRegex().hasMatch(matchPmStr)) {
+            if (hour <= 3 || hour == DateTimeConstants.HalfDayHourCount) {
+              if (hour == DateTimeConstants.HalfDayHourCount) {
+                adjustedHour = 0;
+              }
+
+              deltaHour = 0;
+              adjustedHasAm = true;
+            } else {
+              adjustedHasPm = true;
+            }
+          } else {
+            adjustedHasPm = true;
+          }
+        }
+      }
+    }
+
+    adjustedHour = (adjustedHour + deltaHour) % 24;
+
+    return (adjustedHour, adjustedMin, adjustedHasMin, adjustedHasAm, adjustedHasPm);
+  }
+
+  @override
+  RegExp AtRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.AtRegex);
+
+  @override
+  Map<String, int> Numbers() => config.numbers;
+
+  @override
+  List<RegExp> TimeRegexes() => EnglishTimeExtractorConfiguration(config).TimeRegexList();
+
+  @override
+  String TimeTokenPrefix() => EnglishDateTime.TimeTokenPrefix;
+
+  @override
+  IDateTimeParser TimeZoneParser() {
+    // TODO: implement TimeZoneParser
+    throw UnimplementedError();
+  }
+
+  @override
+  IDateTimeUtilityConfiguration UtilityConfiguration() => EnglishDatetimeUtilityConfiguration();
+
+  RegExp HalfTokenRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.HalfTokenRegex);
+
+  RegExp QuarterTokenRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.QuarterTokenRegex);
+
+  RegExp ThreeQuarterTokenRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.ThreeQuarterTokenRegex);
+
+  RegExp ToTokenRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.ToTokenRegex);
+
+  RegExp TimeSuffixFull() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.TimeSuffixFull);
+
+  RegExp LunchRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.LunchRegex);
+
+  RegExp NightRegex() => RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.NightRegex);
+}

--- a/lib/src/date_time/english_date_period_extraction.dart
+++ b/lib/src/date_time/english_date_period_extraction.dart
@@ -97,7 +97,7 @@ class EnglishDatePeriodExtractorConfiguration
       RegExpComposer.sanitizeGroupsAndCompile(EnglishDateTime.RangeConnectorRegex);
 
   EnglishDatePeriodExtractorConfiguration(super.config) {
-    // datePointExtractor = BaseDateExtractor(EnglishDateExtractorConfiguration(this));
+    //datePointExtractor = BaseDateExtractor(EnglishDateExtractorConfiguration(EnglishDateExtractorConfiguration(super.config)));
     cardinalExtractor = CardinalExtractor.getInstance();
     // ordinalExtractor = OrdinalExtractor.getInstance();
     durationExtractor = DurationExtractor(config: EnglishDurationExtractorConfiguration());

--- a/lib/src/date_time/english_date_time_parser.dart
+++ b/lib/src/date_time/english_date_time_parser.dart
@@ -2,10 +2,16 @@ import 'package:nlp/src/core/english_merged_extractor.dart';
 import 'package:nlp/src/core/extraction.dart';
 import 'package:nlp/src/core/parser.dart';
 import 'package:nlp/src/date_time/base_date_extractor.dart';
+import 'package:nlp/src/date_time/base_date_parser.dart';
+import 'package:nlp/src/date_time/base_datetime_parser.dart';
 import 'package:nlp/src/date_time/base_holiday_extractor.dart';
 import 'package:nlp/src/date_time/base_time_extractor.dart';
+import 'package:nlp/src/date_time/base_time_parser.dart';
+import 'package:nlp/src/date_time/english/english_date_parser_configuration.dart';
+import 'package:nlp/src/date_time/english/english_date_time_parser_configuration.dart';
 import 'package:nlp/src/date_time/english/english_holiday_extractor_configuration.dart';
 import 'package:nlp/src/date_time/english/english_time_extractor_configuration.dart';
+import 'package:nlp/src/date_time/english/english_time_parser_configuration.dart';
 import 'package:nlp/src/date_time/english_date_extractor.dart';
 import 'package:nlp/src/duration/base_duration_parser.dart';
 import 'package:nlp/src/date_time/date_time_extraction.dart';
@@ -116,9 +122,9 @@ class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfigurati
 
     // timeZoneParser = BaseTimeZoneParser();
     durationParser = BaseDurationParser(EnglishDurationParserConfiguration(this));
-    // dateParser = BaseDateParser(EnglishDateParserConfiguration(this));
-    // timeParser = TimeParser(EnglishTimeParserConfiguration(this));
-    // dateTimeParser = BaseDateTimeParser(EnglishDateTimeParserConfiguration(this));
+    dateParser = BaseDateParser(EnglishDateParserConfiguration(this));
+    timeParser = BaseTimeParser(EnglishTimeParserConfiguration(this, options: options));
+    dateTimeParser = BaseDateTimeParser(EnglishDateTimeParserConfiguration(this, options: options));
     // datePeriodParser = BaseDatePeriodParser(EnglishDatePeriodParserConfiguration(this));
     // timePeriodParser = BaseTimePeriodParser(EnglishTimePeriodParserConfiguration(this));
     // dateTimePeriodParser = BaseDateTimePeriodParser(EnglishDateTimePeriodParserConfiguration(this));
@@ -173,8 +179,8 @@ class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfigurati
 
   @override
   late final IDateTimeExtractor timeExtractor;
-  // @override
-  // late final IDateTimeExtractor dateTimeExtractor;
+  @override
+  late final IDateTimeExtractor dateTimeExtractor;
   // @override
   // late final IDateTimeExtractor datePeriodExtractor;
   // @override
@@ -185,10 +191,10 @@ class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfigurati
   @override
   late final IDateTimeExtractor holidayExtractor;
 
-  // @override
-  // late final IDateTimeParser dateParser;
-  // @override
-  // late final IDateTimeParser timeParser;
+  @override
+  late final IDateTimeParser dateParser;
+  @override
+  late final IDateTimeParser timeParser;
   // @override
   // late final IDateTimeParser dateTimeParser;
   @override
@@ -197,6 +203,9 @@ class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfigurati
   late final IDateTimeParser datePeriodParser;
   @override
   late final IDateTimeParser timePeriodParser;
+
+  @override
+  late final IDateTimeParser dateTimeParser;
 
   // @override
   // late final IDateTimeParser dateTimePeriodParser;
@@ -226,7 +235,7 @@ abstract interface class ICommonDateTimeParserConfiguration implements IOptionsC
 
   IDateTimeExtractor get timeExtractor;
 
-  // IDateTimeExtractor get dateTimeExtractor;
+  IDateTimeExtractor get dateTimeExtractor;
 
   IDateTimeExtractor get durationExtractor;
 
@@ -237,11 +246,11 @@ abstract interface class ICommonDateTimeParserConfiguration implements IOptionsC
   // IDateTimeExtractor get dateTimePeriodExtractor;
 
   IDateTimeExtractor get holidayExtractor;
-  // IDateTimeParser get dateParser;
+  IDateTimeParser get dateParser;
 
-  // IDateTimeParser get timeParser;
+  IDateTimeParser get timeParser;
 
-  // IDateTimeParser get dateTimeParser;
+  IDateTimeParser get dateTimeParser;
 
   IDateTimeParser get durationParser;
 

--- a/lib/src/date_time/english_date_time_parser.dart
+++ b/lib/src/date_time/english_date_time_parser.dart
@@ -3,7 +3,9 @@ import 'package:nlp/src/core/extraction.dart';
 import 'package:nlp/src/core/parser.dart';
 import 'package:nlp/src/date_time/base_date_extractor.dart';
 import 'package:nlp/src/date_time/base_holiday_extractor.dart';
+import 'package:nlp/src/date_time/base_time_extractor.dart';
 import 'package:nlp/src/date_time/english/english_holiday_extractor_configuration.dart';
+import 'package:nlp/src/date_time/english/english_time_extractor_configuration.dart';
 import 'package:nlp/src/date_time/english_date_extractor.dart';
 import 'package:nlp/src/duration/base_duration_parser.dart';
 import 'package:nlp/src/date_time/date_time_extraction.dart';
@@ -105,7 +107,7 @@ class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfigurati
 
     durationExtractor = DurationExtractor(config: EnglishDurationExtractorConfiguration());
     dateExtractor = BaseDateExtractor(EnglishDateExtractorConfiguration(this));
-    // timeExtractor = BaseTimeExtractor(EnglishTimeExtractorConfiguration(options));
+    timeExtractor = BaseTimeExtractor(EnglishTimeExtractorConfiguration(this));
     // dateTimeExtractor = BaseDateTimeExtractor(EnglishDateTimeExtractorConfiguration(options));
     // datePeriodExtractor = BaseDatePeriodExtractor(EnglishDatePeriodExtractorConfiguration(this));
     // timePeriodExtractor = BaseTimePeriodExtractor(EnglishTimePeriodExtractorConfiguration(options));
@@ -168,8 +170,9 @@ class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfigurati
 
   @override
   late final IDateExtractor dateExtractor;
-  // @override
-  // late final IDateTimeExtractor timeExtractor;
+
+  @override
+  late final IDateTimeExtractor timeExtractor;
   // @override
   // late final IDateTimeExtractor dateTimeExtractor;
   // @override
@@ -221,7 +224,7 @@ abstract interface class ICommonDateTimeParserConfiguration implements IOptionsC
 
   IDateExtractor get dateExtractor;
 
-  // IDateTimeExtractor get timeExtractor;
+  IDateTimeExtractor get timeExtractor;
 
   // IDateTimeExtractor get dateTimeExtractor;
 

--- a/lib/src/date_time/extract_result_extension.dart
+++ b/lib/src/date_time/extract_result_extension.dart
@@ -1,0 +1,20 @@
+import 'package:nlp/src/core/extraction.dart';
+
+class ExtractResultExtension {
+  static List<ExtractResult> FilterAmbiguity(
+      List<ExtractResult> extractResults, String text, Map<RegExp, RegExp> ambiguityFiltersDict) {
+    for (var regex in ambiguityFiltersDict.entries) {
+      for (int i = extractResults.length - 1; i >= 0; i--) {
+        var er = extractResults[i];
+        if (regex.key.hasMatch(er.text)) {
+          var matches = regex.value.allMatches(text);
+          if (matches.any((match) => match.start < er.start + er.length && match.end > er.start)) {
+            extractResults.removeAt(i);
+          }
+        }
+      }
+    }
+
+    return extractResults;
+  }
+}

--- a/lib/src/date_time/timezone_utility.dart
+++ b/lib/src/date_time/timezone_utility.dart
@@ -1,0 +1,103 @@
+import 'package:nlp/src/core/extraction.dart';
+import 'package:nlp/src/core/string_matcher.dart';
+import 'package:nlp/src/date_time/constants.dart';
+import 'package:nlp/src/date_time/english_date_time.dart';
+import 'package:nlp/src/duration/duration.dart';
+import 'package:nlp/src/numbers/number_with_unit_tokenizer.dart';
+import 'package:nlp/src/regular_expressions/regular_expressions_extensions.dart';
+
+class TimeZoneUtility {
+  // private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
+  // private static readonly Regex BracketRegex =
+  //     new Regex(BaseDateTime.BracketRegex, RegexFlags, RegexTimeOut);
+
+  static RegExp BracketRegex = RegExpComposer.sanitizeGroupsAndCompile(BaseDateTime.BracketRegex);
+
+  // private static TimeSpan RegexTimeOut => DateTimeRecognizer.GetTimeout(MethodBase.GetCurrentMethod().DeclaringType);
+
+  static List<ExtractResult> MergeTimeZones(
+      List<ExtractResult> originalErs, List<ExtractResult> timeZoneErs, String text) {
+    for (var er in originalErs) {
+      for (var timeZoneEr in timeZoneErs) {
+        // Extend timezone extraction to include brackets if any.
+        var tzEr = ExtendTimeZoneExtraction(timeZoneEr, text);
+
+        var begin = er.start + er.length;
+        var end = tzEr.start;
+
+        if (begin < end) {
+          var gapText = text.substring(begin, end);
+
+          if (gapText.trim().isEmpty) {
+            var newLength = (tzEr.start + tzEr.length - er.start);
+
+            er.text = text.substring(er.start, er.start + newLength);
+            er.length = newLength;
+            er.data = <String, Object>{
+              DateTimeConstants.SYS_DATETIME_TIMEZONE: timeZoneEr,
+            };
+          }
+        }
+
+        // Make sure timezone info propagates to longer span entity.
+        if (er.isOverlap(timeZoneEr)) {
+          er.data = <String, Object>{
+            DateTimeConstants.SYS_DATETIME_TIMEZONE: timeZoneEr,
+          };
+        }
+      }
+    }
+
+    return originalErs;
+  }
+
+  static bool ShouldResolveTimeZone(ExtractResult er, DateTimeOptions options) {
+    var enablePreview = options.match(DateTimeOptions.EnablePreview);
+    if (!enablePreview) {
+      return false;
+    }
+
+    var hasTimeZoneData = false;
+
+    if (er.data is Map<String, Object>) {
+      var metaData = er.data as Map<String, Object>;
+
+      if (metaData.containsKey(DateTimeConstants.SYS_DATETIME_TIMEZONE)) {
+        hasTimeZoneData = true;
+      }
+    }
+
+    return hasTimeZoneData;
+  }
+
+  static StringMatcher BuildMatcherFromLists(List<List<String>> collections) {
+    StringMatcher matcher = StringMatcher(strategy: MatchStrategy.TrieTree, tokenizer: NumberWithUnitTokenizer());
+    List<String> matcherList = <String>[];
+
+    for (List<String> collection in collections) {
+      for (final matcher in collection) {
+        matcherList.add(matcher.trim().toLowerCase());
+      }
+    }
+
+    matcherList = matcherList.toSet().toList();
+
+    matcher.initFromValues(matcherList);
+
+    return matcher;
+  }
+
+  static ExtractResult ExtendTimeZoneExtraction(ExtractResult timeZoneEr, String text) {
+    var beforeStr = text.substring(0, timeZoneEr.start + 1);
+    var afterStr = text.substring(timeZoneEr.start + timeZoneEr.length);
+    var matchLeft = BracketRegex.firstMatch(beforeStr);
+    var matchRight = BracketRegex.firstMatch(afterStr);
+    if (matchLeft != null && matchRight != null) {
+      timeZoneEr.start -= matchLeft.length;
+      timeZoneEr.length += matchLeft.length + matchRight.length;
+    }
+
+    return timeZoneEr;
+  }
+}

--- a/lib/src/duration/duration.dart
+++ b/lib/src/duration/duration.dart
@@ -92,7 +92,7 @@ class DurationParsingUtil {
         // result = DateUtil.plusPeriodInNanos(result, number * futureOrPast, chronoUnit);
         final nanos = chronoUnit.duration.inMicroseconds;
         final micros = result.microsecondsSinceEpoch + ((number * futureOrPast) * nanos).round();
-        return DateTime.fromMicrosecondsSinceEpoch(micros);
+        result = DateTime.fromMicrosecondsSinceEpoch(micros);
       }
     }
     return result;

--- a/lib/src/duration/duration_extractor.dart
+++ b/lib/src/duration/duration_extractor.dart
@@ -270,7 +270,7 @@ class DurationExtractor implements IDateTimeExtractor {
       print(" - matching against: '${config.getMoreThanRegex().pattern}'");
       bool isInequalityPrefixMatched = false;
 
-      var match = config.getMoreThanRegex().matchEnd(beforeString);
+      var match = config.getMoreThanRegex().matchEnd(beforeString, true);
       print(" - match: $match");
 
       // The second condition is necessary so for "1 week" in "more than 4 days and less than 1 week",
@@ -283,7 +283,7 @@ class DurationExtractor implements IDateTimeExtractor {
 
       if (!isInequalityPrefixMatched) {
         print(" - didn't match MORE, now trying LESS");
-        match = config.getLessThanRegex().matchEnd(beforeString);
+        match = config.getLessThanRegex().matchEnd(beforeString, true);
 
         if (match != null) {
           er.data = DateTimeConstants.LESS_THAN_MOD;


### PR DESCRIPTION
This PR ports the datetime extractor and parser with all existing tests passing.

This PR also fix a bug in the duration extractor, which was calling match exact without trimming the end, which was causing some datetime tests to fail.